### PR TITLE
beeper_off_cells_min

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -377,6 +377,7 @@ static void resetConf(void)
     setControlRateProfile(0);
 
     masterConfig.beeper_off.flags = BEEPER_OFF_FLAGS_MIN;
+    masterConfig.beeper_off.cells_min = BEEPER_OFF_CELLS_DEFAULT;
     masterConfig.version = EEPROM_CONF_VERSION;
     masterConfig.mixerMode = MIXER_QUADX;
     featureClearAll();

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -211,7 +211,7 @@ static const beeperTableEntry_t *currentBeeperEntry = NULL;
  */
 void beeper(beeperMode_e mode)
 {
-    if (mode == BEEPER_SILENCE || (feature(FEATURE_VBAT) && (batteryCellCount < 2))) {
+    if (mode == BEEPER_SILENCE || (feature(FEATURE_VBAT) && (batteryCellCount < masterConfig.beeper_off.cells_min))) {
         beeperSilence();
         return;
     }

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -40,11 +40,13 @@ typedef enum {
     BEEPER_CASE_MAX
 } beeperMode_e;
 
+#define BEEPER_OFF_CELLS_DEFAULT  2 // default cell count to activate the beeper
 #define BEEPER_OFF_FLAGS_MIN  0
 #define BEEPER_OFF_FLAGS_MAX  ((1 << (BEEPER_CASE_MAX - 1)) - 1)
 
 typedef struct beeperOffConditions_t {
     uint32_t flags;
+    uint8_t cells_min;
 } beeperOffConditions_t;
 
 void beeper(beeperMode_e mode);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -544,6 +544,7 @@ const clivalue_t valueTable[] = {
     { "magzero_z",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Z], -32768, 32767 },
 
     { "beeper_off_flags",           VAR_UINT32  | MASTER_VALUE, &masterConfig.beeper_off.flags, BEEPER_OFF_FLAGS_MIN, BEEPER_OFF_FLAGS_MAX },
+    { "beeper_off_cells_min",       VAR_UINT8  | MASTER_VALUE, &masterConfig.beeper_off.cells_min, 1, 250 },
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))


### PR DESCRIPTION
Added beeper_off_cells_min cli variable. Allows the user to configure the minimum 'battery cell count' before the beeper/buzzer is active.
This is helpful when the board is powered by USB and is based on the commit 'Inhibit the %^0$ buzzer on USB power' (bbf70c637076d6185deb3d8d34858520987e9ea1).

I use vbat_scale = 114 as I have a diode between my Seriously Dodo FC and the main power source my voltage appears to be 5.6 volts when powered by USB, which appears to be a cell count of 2.
In my case:
if (mode == BEEPER_SILENCE || (feature(FEATURE_VBAT) && (batteryCellCount < 2))) {
would need to be
if (mode == BEEPER_SILENCE || (feature(FEATURE_VBAT) && (batteryCellCount < 3))) {

therefore I made the battery cell count user configurable.
if (mode == BEEPER_SILENCE || (feature(FEATURE_VBAT) && (batteryCellCount < masterConfig.beeper_off.cells_min))) {