### PR TITLE
Fix TARGET_BOARD_IDENTIFIER for IRCFUSIONF3

### DIFF
--- a/src/main/target/IRCFUSIONF3/target.h
+++ b/src/main/target/IRCFUSIONF3/target.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TARGET_BOARD_IDENTIFIER "IRCF3"
+#define TARGET_BOARD_IDENTIFIER "IFF3"
 
 #define LED0_GPIO   GPIOB
 #define LED0_PIN    Pin_3


### PR DESCRIPTION
Only 4  characters allowed, so set it as IFF3.