### PR TITLE
Prevent startup crash on targets without any I2C sensors

### DIFF
--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -83,7 +83,11 @@ mpuDetectionResult_t *detectMpu(const extiConfig_t *configToUse)
     // MPU datasheet specifies 30ms.
     delay(35);
 
+#ifndef USE_I2C
+    ack = false;
+#else
     ack = mpuReadRegisterI2C(MPU_RA_WHO_AM_I, 1, &sig);
+#endif
     if (ack) {
         mpuConfiguration.read = mpuReadRegisterI2C;
         mpuConfiguration.write = mpuWriteRegisterI2C;


### PR DESCRIPTION
This call to an uninitialized i2c peripheral causes crashes on targets that do not have any use of i2c, and therefore have not initialized any i2c periphal. Since the use of i2c is set as a preprocessor define it makes sense to check for that here too.