### PR TITLE
Update config.c for blackbox denom = 2

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -548,7 +548,7 @@ static void resetConf(void)
     masterConfig.blackbox_device = 0;
 #endif
     masterConfig.blackbox_rate_num = 1;
-    masterConfig.blackbox_rate_denom = 1;
+    masterConfig.blackbox_rate_denom = 2;
 #endif
 
     // alternative defaults settings for ALIENWIIF1 and ALIENWIIF3 targets


### PR DESCRIPTION
Not that important, but may help common issues and questions that pertain only to Betaflight blackbox use. 
Change default to set blackbox_rate_denom = 2 since Betaflight runs at 1000 looptime and a 1/1 can causes corruption at that speed to the blackbox log. 1/2 will work for everyone and 1/1 can be configured later if desired. Spoke to Joshua Bardwell and he is using 1/1 but must disable ACC for it to be stable. Blackbox.md explains the use and benefit to a 1/1 setting so a user is likely to try that too, but a default 1/2 will at least get it working to start.