### PR TITLE
Fix Selectable Buzzer Pin for CC3D -Cleanup

### DIFF
--- a/src/main/drivers/sound_beeper.c
+++ b/src/main/drivers/sound_beeper.c
@@ -63,20 +63,12 @@ void systemBeep(bool onoff)
 #endif
 }
 
-#ifdef CC3D
-void beeperInit(beeperConfig_t *config, uint8_t use_buzzer_p6) {
-	if (use_buzzer_p6) {
-        beeperPin = Pin_2;
-	} else {
-        beeperPin = BEEP_PIN;
-	}
-#else
-void beeperInit(beeperConfig_t *config) {
-	beeperPin = BEEP_PIN;
-#endif
+void beeperInit(beeperConfig_t *config)
+{
 #ifndef BEEPER
     UNUSED(config);
 #else
+    beeperPin = config->gpioPin;
     initBeeperHardware(config);
     if (config->isInverted)
         systemBeepPtr = beepInverted;

--- a/src/main/drivers/sound_beeper.h
+++ b/src/main/drivers/sound_beeper.h
@@ -36,10 +36,6 @@ typedef struct beeperConfig_s {
 } beeperConfig_t;
 
 void systemBeep(bool onoff);
-#ifdef CC3D
-void beeperInit(beeperConfig_t *beeperConfig, uint8_t use_buzzer_p6);
-#else
 void beeperInit(beeperConfig_t *beeperConfig);
-#endif
 
 void initBeeperHardware(beeperConfig_t *config);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -306,11 +306,9 @@ void init(void)
 #ifdef CC3D
     if (masterConfig.use_buzzer_p6 == 1)
         beeperConfig.gpioPin = Pin_2;
-
-    beeperInit(&beeperConfig, masterConfig.use_buzzer_p6);
-#else
-    beeperInit(&beeperConfig);
 #endif
+
+    beeperInit(&beeperConfig);
 #endif
 
 #ifdef INVERTER

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -27,7 +27,6 @@
 #define INVERTER_PERIPHERAL RCC_APB2Periph_GPIOB
 #define INVERTER_USART USART1
 
-//#define BEEPER_PIN6 // Uncomment this line for hexacopter configurations where PIN6 is needed for motor
 
 #define BEEP_GPIO GPIOA
 #define BEEP_PIN Pin_15 // PA15 (Beeper)


### PR DESCRIPTION
I think you introduced some kind of double logic that wasn´t really necessary.
This should be cleaner and works the same.
Pin2 was already inside beeperConfig.gpioPin and BEEP_PIN for the other targets will be assigned here anyway https://github.com/borisbstyle/betaflight/blob/betaflight/src/main/main.c#L285


