### PR TITLE
Re-enable BLACKBOX and disable GPS instead too fit CC3D_OPBL.

### DIFF
--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -138,7 +138,8 @@
 #undef SONAR
 #if defined(OPBL) && defined(USE_SERIAL_1WIRE)
 #undef BARO
-#undef BLACKBOX
+//#undef BLACKBOX
+#undef GPS
 #endif
 #define SKIP_CLI_COMMAND_HELP
 


### PR DESCRIPTION
I made a quick test and found that it is the removal of BLACKBOX feature that causes the problem. I could repeat the same problem on the native non-OPBL variant too. I have however not been digging deeper into the problem to find the root-cause.  
To me it seems better to keep BLACKBOX, since CC3D has a SPI data flash,   and instead remove GPS to make the code fit. 
/A
