### PR TITLE
bmp085 and bmp180 on spracingf3 and derivatives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -619,6 +619,7 @@ SPRACINGF3_SRC = \
 		   drivers/accgyro_mpu6050.c \
 		   drivers/barometer_ms5611.c \
 		   drivers/compass_ak8975.c \
+		   drivers/barometer_bmp085.c \
 		   drivers/barometer_bmp280.c \
 		   drivers/compass_hmc5883l.c \
 		   drivers/display_ug2864hsweg01.h \

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -49,6 +49,7 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP085
 #define USE_BARO_BMP280
 
 #define MAG


### PR DESCRIPTION
instead of: https://github.com/borisbstyle/betaflight/pull/117
