### PR TITLE
Firmware version added to build artifacts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,12 @@ endif
 
 REVISION = $(shell git log -1 --format="%h")
 
+FC_VER_MAJOR := $(shell grep " FC_VERSION_MAJOR" src/main/version.h | awk '{print $$3}' )
+FC_VER_MINOR := $(shell grep " FC_VERSION_MINOR" src/main/version.h | awk '{print $$3}' )
+FC_VER_PATCH := $(shell grep " FC_VERSION_PATCH" src/main/version.h | awk '{print $$3}' )
+
+FC_VER := $(FC_VER_MAJOR).$(FC_VER_MINOR).$(FC_VER_PATCH)
+
 # Working directories
 ROOT		 := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC_DIR		 = $(ROOT)/src/main
@@ -761,8 +767,8 @@ endif
 
 CC3D_OPBL_SRC     = $(CC3D_SRC)
 
-TARGET_BIN	 = $(BIN_DIR)/$(FORKNAME)_$(TARGET).bin
-TARGET_HEX	 = $(BIN_DIR)/$(FORKNAME)_$(TARGET).hex
+TARGET_BIN	 = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET).bin
+TARGET_HEX	 = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET).hex
 TARGET_ELF	 = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET).elf
 TARGET_OBJS	 = $(addsuffix .o,$(addprefix $(OBJECT_DIR)/$(TARGET)/,$(basename $($(TARGET)_SRC))))
 TARGET_DEPS	 = $(addsuffix .d,$(addprefix $(OBJECT_DIR)/$(TARGET)/,$(basename $($(TARGET)_SRC))))


### PR DESCRIPTION
There was some requirements or wishes for version labels in the build artifact file names on RCG. Your wishes are my command, Makefile updated to do this. 
Filename formats now like this: 

    betaflight_2.3.4_ALIENFLIGHTF1.hex
    betaflight_2.3.4_ALIENFLIGHTF3.hex
    betaflight_2.3.4_CC3D.hex
    betaflight_2.3.4_CC3D_OPBL.bin
    betaflight_2.3.4_CHEBUZZF3.hex
    betaflight_2.3.4_COLIBRI_RACE.hex
    betaflight_2.3.4_EUSTM32F103RC.hex
    betaflight_2.3.4_IRCFUSIONF3.hex
    betaflight_2.3.4_LUX_RACE.hex
    betaflight_2.3.4_MOTOLAB.hex
    betaflight_2.3.4_NAZE32PRO.hex
    betaflight_2.3.4_NAZE.hex
    betaflight_2.3.4_OLIMEXINO.hex
    betaflight_2.3.4_PORT103R.hex
    betaflight_2.3.4_RMDO.hex 
    betaflight_2.3.4_SPARKY.hex
    betaflight_2.3.4_SPRACINGF3.hex
    betaflight_2.3.4_STM32F3DISCOVERY.hex

We could add git rev hash as well, if there is a need for such details.. Later..
/A
