### PR TITLE
Move 1wire to USART2

### DIFF
--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -184,8 +184,8 @@
 #define BIND_PIN   Pin_5
 
 #define USE_SERIAL_1WIRE
-// Untested and will probably not work with RX_Serial on USART1
-#define S1W_TX_GPIO         GPIOC
-#define S1W_TX_PIN          GPIO_Pin_4
-#define S1W_RX_GPIO         GPIOC
-#define S1W_RX_PIN          GPIO_Pin_5
+// USART2, RX is on USART1
+#define S1W_TX_GPIO         GPIOA
+#define S1W_TX_PIN          GPIO_Pin_14
+#define S1W_RX_GPIO         GPIOA
+#define S1W_RX_PIN          GPIO_Pin_15


### PR DESCRIPTION
Move 1wire over to USART2, if the RX is hooked up to USART1 (which is the default), it will cause a conflict when trying to use 1wire.