### PR TITLE
Sorry, it should be on USART3.

### DIFF
--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -185,7 +185,7 @@
 
 #define USE_SERIAL_1WIRE
 // USART2, RX is on USART1
-#define S1W_TX_GPIO         GPIOA
-#define S1W_TX_PIN          GPIO_Pin_14
-#define S1W_RX_GPIO         GPIOA
-#define S1W_RX_PIN          GPIO_Pin_15
+#define S1W_TX_GPIO         GPIOB
+#define S1W_TX_PIN          GPIO_Pin_10
+#define S1W_RX_GPIO         GPIOB
+#define S1W_RX_PIN          GPIO_Pin_11


### PR DESCRIPTION
Realized that the RACE target in CF has serial RX on USART2, moved to USART3 for continuity between branches.