### PR TITLE
Table lookup for hardware settings

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -364,7 +364,7 @@ static const char * const lookupTableGyroLpf[] = {
 
 static const char * const lookupTableAccHardware[] = {
 	"AUTO", 
-	"OFF", 
+	"NONE", 
 	"ADXL345",
 	"MPU6050",
 	"MMA8452",
@@ -377,7 +377,7 @@ static const char * const lookupTableAccHardware[] = {
 
 static const char * const lookupTableBaroHardware[] = {
 	"AUTO",
-    "OFF",
+    "NONE",
     "BMP085",
     "MS5611",
     "BMP280"
@@ -385,7 +385,7 @@ static const char * const lookupTableBaroHardware[] = {
 
 static const char * const lookupTableMagHardware[] = {
     "AUTO",
-    "OFF",
+    "NONE",
     "HMC5883",
     "AK8975",
     "AK8963"

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -362,6 +362,35 @@ static const char * const lookupTableGyroLpf[] = {
     "42HZ"
 };
 
+static const char * const lookupTableAccHardware[] = {
+	"AUTO", 
+	"OFF", 
+	"ADXL345",
+	"MPU6050",
+	"MMA8452",
+	"BMA280",
+	"LSM303DLHC",
+	"MPU6000",
+	"MPU6500",
+	"FAKE"
+};
+
+static const char * const lookupTableBaroHardware[] = {
+	"AUTO",
+    "OFF",
+    "BMP085",
+    "MS5611",
+    "BMP280"
+};
+
+static const char * const lookupTableMagHardware[] = {
+    "AUTO",
+    "OFF",
+    "HMC5883",
+    "AK8975",
+    "AK8963"
+};
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -383,6 +412,9 @@ typedef enum {
     TABLE_PID_CONTROLLER,
     TABLE_SERIAL_RX,
     TABLE_GYRO_LPF,
+    TABLE_ACC_HARDWARE,
+    TABLE_BARO_HARDWARE,
+    TABLE_MAG_HARDWARE,
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -398,7 +430,10 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableGimbalMode, sizeof(lookupTableGimbalMode) / sizeof(char *) },
     { lookupTablePidController, sizeof(lookupTablePidController) / sizeof(char *) },
     { lookupTableSerialRX, sizeof(lookupTableSerialRX) / sizeof(char *) },
-    { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) }
+    { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) },
+    { lookupTableAccHardware, sizeof(lookupTableAccHardware) / sizeof(char *) },
+    { lookupTableBaroHardware, sizeof(lookupTableBaroHardware) / sizeof(char *) },
+    { lookupTableMagHardware, sizeof(lookupTableMagHardware) / sizeof(char *) }
 };
 
 #define VALUE_TYPE_OFFSET 0
@@ -601,7 +636,7 @@ const clivalue_t valueTable[] = {
     { "gimbal_mode",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].gimbalConfig.mode, .config.lookup = { TABLE_GIMBAL_MODE } },
 #endif
 
-    { "acc_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.acc_hardware, .config.minmax = { 0,  ACC_MAX } },
+    { "acc_hardware",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.acc_hardware, .config.lookup = { TABLE_ACC_HARDWARE } },
     { "acc_lpf_hz",                 VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].acc_lpf_hz, .config.minmax = { 0,  200 } },
     { "accxy_deadband",             VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].accDeadband.xy, .config.minmax = { 0,  100 } },
     { "accz_deadband",              VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].accDeadband.z, .config.minmax = { 0,  100 } },
@@ -614,9 +649,9 @@ const clivalue_t valueTable[] = {
     { "baro_noise_lpf",             VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_noise_lpf, .config.minmax = { 0 , 1 } },
     { "baro_cf_vel",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_cf_vel, .config.minmax = { 0 , 1 } },
     { "baro_cf_alt",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_cf_alt, .config.minmax = { 0 , 1 } },
-    { "baro_hardware",              VAR_UINT8  | MASTER_VALUE,  &masterConfig.baro_hardware, .config.minmax = { 0,  BARO_MAX } },
+    { "baro_hardware",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.baro_hardware, .config.lookup = { TABLE_BARO_HARDWARE } },
 
-    { "mag_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.mag_hardware, .config.minmax = { 0,  MAG_MAX } },
+    { "mag_hardware",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.mag_hardware, .config.lookup = { TABLE_MAG_HARDWARE } },
     { "mag_declination",            VAR_INT16  | PROFILE_VALUE, &masterConfig.profile[0].mag_declination, .config.minmax = { -18000,  18000 } },
     { "delta_from_gyro",            VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.deltaFromGyro, .config.lookup = { TABLE_OFF_ON } },
 


### PR DESCRIPTION
Simplifications for cli settings for hardware. 

Using set acc_hardware = 1 for off really doesn't make logical sense. This PR maps commands to "AUTO" & "NONE" instead. 


 