### PR TITLE
Mute RX_LOST beep if the copter was never armed

### DIFF
--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -21,7 +21,8 @@
 typedef enum {
     OK_TO_ARM       = (1 << 0),
     PREVENT_ARMING  = (1 << 1),
-    ARMED           = (1 << 2)
+    ARMED           = (1 << 2),
+	WAS_EVER_ARMED  = (1 << 3)
 } armingFlag_e;
 
 extern uint8_t armingFlags;

--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -22,7 +22,7 @@ typedef enum {
     OK_TO_ARM       = (1 << 0),
     PREVENT_ARMING  = (1 << 1),
     ARMED           = (1 << 2),
-	WAS_EVER_ARMED  = (1 << 3)
+    WAS_EVER_ARMED  = (1 << 3)
 } armingFlag_e;
 
 extern uint8_t armingFlags;

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -172,8 +172,8 @@ void failsafeUpdateState(void)
     bool failsafeSwitchIsOn = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
     beeperMode_e beeperMode = BEEPER_SILENCE;
 
-	// Beep RX lost only if we are not seeing data, but we have seen it in the past.
-    if (!receivingRxData && failsafeState.validRxDataReceivedAt) {
+	// Beep RX lost only if we are not seeing data and we have been armed earlier
+    if (!receivingRxData && ARMING_FLAG(WAS_EVER_ARMED)) {
         beeperMode = BEEPER_RX_LOST;
     }
 

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -172,7 +172,8 @@ void failsafeUpdateState(void)
     bool failsafeSwitchIsOn = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
     beeperMode_e beeperMode = BEEPER_SILENCE;
 
-    if (!receivingRxData) {
+	// Beep RX lost only if we are not seeing data, but we have seen it in the past.
+    if (!receivingRxData && failsafeState.validRxDataReceivedAt) {
         beeperMode = BEEPER_RX_LOST;
     }
 

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -172,7 +172,7 @@ void failsafeUpdateState(void)
     bool failsafeSwitchIsOn = IS_RC_MODE_ACTIVE(BOXFAILSAFE);
     beeperMode_e beeperMode = BEEPER_SILENCE;
 
-	// Beep RX lost only if we are not seeing data and we have been armed earlier
+    // Beep RX lost only if we are not seeing data and we have been armed earlier
     if (!receivingRxData && ARMING_FLAG(WAS_EVER_ARMED)) {
         beeperMode = BEEPER_RX_LOST;
     }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -224,7 +224,7 @@ static float imuGetPGainScaleFactor(void)
 }
 
 static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
-                                float useAcc, float ax, float ay, float az,
+                                bool useAcc, float ax, float ay, float az,
                                 bool useMag, float mx, float my, float mz,
                                 bool useYaw, float yawError)
 {
@@ -272,21 +272,19 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
         ez += rMat[2][2] * ez_ef;
     }
 
-    if (useAcc > 0.0f) {
-		// Just scale by 1G length - That's our vector adjustment. Rather than 
-		// using one-over-exact length (which needs a costly square root), we already 
-		// know the vector is enough "roughly unit length" and since it is only weighted
-		// in by a certain amount anyway later, having that exact is meaningless.
- 	    recipNorm = 1.0f / acc_1G;; 		
-
+    // Use measured acceleration vector
+    recipNorm = sq(ax) + sq(ay) + sq(az);
+    if (useAcc && recipNorm > 0.01f) {
+        // Normalise accelerometer measurement
+        recipNorm = invSqrt(recipNorm);
         ax *= recipNorm;
         ay *= recipNorm;
         az *= recipNorm;
-        
 
-        ex += (ay * rMat[2][2] - az * rMat[2][1]) * useAcc;
-        ey += (az * rMat[2][0] - ax * rMat[2][2]) * useAcc;
-        ez += (ax * rMat[2][1] - ay * rMat[2][0]) * useAcc;
+        // Error is sum of cross product between estimated direction and measured direction of gravity
+        ex += (ay * rMat[2][2] - az * rMat[2][1]);
+        ey += (az * rMat[2][0] - ax * rMat[2][2]);
+        ez += (ax * rMat[2][1] - ay * rMat[2][0]);
     }
 
     // Compute and apply integral feedback if enabled
@@ -355,7 +353,7 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
     }
 }
 
-static float imuAccelerometerWeight(void)
+static bool imuIsAccelerometerHealthy(void)
 {
     int32_t axis;
     int32_t accMagnitude = 0;
@@ -364,11 +362,10 @@ static float imuAccelerometerWeight(void)
         accMagnitude += (int32_t)accSmooth[axis] * accSmooth[axis];
     }
 
-    accMagnitude = accMagnitude * 100 / ((((int32_t)acc_1G)*((int32_t)acc_1G)));
+    accMagnitude = accMagnitude * 100 / (sq((int32_t)acc_1G));
 
-	int32_t nearness = ABS(100 - accMagnitude);
-	if (nearness > 25) return 0.0f;
-	return 1.0f - (nearness / 25.0f);
+    // Accept accel readings only in range 0.90g - 1.10g
+    return (81 < accMagnitude) && (accMagnitude < 121);
 }
 
 static bool isMagnetometerHealthy(void)
@@ -380,7 +377,7 @@ static void imuCalculateEstimatedAttitude(void)
 {
     static uint32_t previousIMUUpdateTime;
     float rawYawError = 0;
-    float useAcc = 0.0f;
+    bool useAcc = false;
     bool useMag = false;
     bool useYaw = false;
 
@@ -388,7 +385,9 @@ static void imuCalculateEstimatedAttitude(void)
     uint32_t deltaT = currentTime - previousIMUUpdateTime;
     previousIMUUpdateTime = currentTime;
 
-    useAcc = imuAccelerometerWeight();
+    if (imuIsAccelerometerHealthy()) {
+        useAcc = true;
+    }
 
     if (sensors(SENSOR_MAG) && isMagnetometerHealthy()) {
         useMag = true;

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -366,7 +366,7 @@ void mwArm(void)
         }
         if (!ARMING_FLAG(PREVENT_ARMING)) {
             ENABLE_ARMING_FLAG(ARMED);
-			ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
+            ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
             headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
 #ifdef BLACKBOX

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -366,6 +366,7 @@ void mwArm(void)
         }
         if (!ARMING_FLAG(PREVENT_ARMING)) {
             ENABLE_ARMING_FLAG(ARMED);
+			ENABLE_ARMING_FLAG(WAS_EVER_ARMED);
             headFreeModeHold = DECIDEGREES_TO_DEGREES(attitude.values.yaw);
 
 #ifdef BLACKBOX


### PR DESCRIPTION
Nothing is more annoying than beeping just because you plugged in the  battery, or the USB.

This makes the RX_LOST beeper active only in the case that make any sense - you've flown. (Or specifically, you had armed the copter at some point)