### PR TITLE
Remove VBATT_HYSTERESIS

### DIFF
--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -83,8 +83,6 @@ static void updateBatteryVoltage(void)
 }
 
 #define VBATTERY_STABLE_DELAY 40
-/* Batt Hysteresis of +/-100mV */
-#define VBATT_HYSTERESIS 1
 
 void updateBattery(void)
 {
@@ -123,23 +121,23 @@ void updateBattery(void)
     switch(batteryState)
     {
         case BATTERY_OK:
-            if (vbat <= (batteryWarningVoltage - VBATT_HYSTERESIS)) {
+            if (vbat <= (batteryWarningVoltage)) {
                 batteryState = BATTERY_WARNING;
                 beeper(BEEPER_BAT_LOW);
             }
             break;
         case BATTERY_WARNING:
-            if (vbat <= (batteryCriticalVoltage - VBATT_HYSTERESIS)) {
+            if (vbat <= (batteryCriticalVoltage)) {
                 batteryState = BATTERY_CRITICAL;
                 beeper(BEEPER_BAT_CRIT_LOW);
-            } else if (vbat > (batteryWarningVoltage + VBATT_HYSTERESIS)){
+            } else if (vbat > (batteryWarningVoltage)){
                 batteryState = BATTERY_OK;
             } else {
                 beeper(BEEPER_BAT_LOW);
             }
             break;
         case BATTERY_CRITICAL:
-            if (vbat > (batteryCriticalVoltage + VBATT_HYSTERESIS)){
+            if (vbat > (batteryCriticalVoltage)){
                 batteryState = BATTERY_WARNING;
                 beeper(BEEPER_BAT_LOW);
             } else {

--- a/src/test/unit/battery_unittest.cc
+++ b/src/test/unit/battery_unittest.cc
@@ -119,18 +119,24 @@ TEST(BatteryTest, BatteryState)
     batteryAdcToBatteryStateExpectation_t batteryAdcToBatteryStateExpectations[] = {
             {1420, 126, BATTERY_OK, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
             /* fall down to battery warning level */
-            {1185, 105, BATTERY_OK, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
-            {1175, 104, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
-            /* creep back up to battery ok */
+            {1195, 106, BATTERY_OK, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
             {1185, 105, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
-            {1195, 106, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1175, 104, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1165, 103, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            /* creep back up to battery ok */
+            {1175, 104, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1185, 105, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1195, 106, BATTERY_OK, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
             {1207, 107, BATTERY_OK, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
             /* fall down to battery critical level */
             {1175, 104, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
-            {1108, 98, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
-            /* creep back up to battery warning */
             {1115, 99, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
-            {1130, 100, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1108, 98, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1095, 97, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            /* creep back up to battery warning */
+            {1108, 98, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1115, 99, BATTERY_CRITICAL, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
+            {1130, 100, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
             {1145, 101, BATTERY_WARNING, ELEVEN_TO_ONE_VOLTAGE_DIVIDER},
 
     };


### PR DESCRIPTION
The VBATT_HYSTERESIS functionality was added when the battery-state detection code was reworked in Cleanflight a while back, but the hysteresis is not needed and negatively impacts the battery-low alarms.  It adds an annoying time-delay lag to the warning-beep response, and on 1S micro setups the alarm tends to get "stuck" on when it shouldn't.  With VBATT_HYSTERESIS removed, the alarm tracks the state of battery like it should.

This PR removes VBATT_HYSTERESIS from 'battery.c', and updates the battery unit tests accordingly.

--ET