### PR TITLE
Add 'vbat_hysteresis' parameter

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -272,6 +272,7 @@ void resetBatteryConfig(batteryConfig_t *batteryConfig)
     batteryConfig->vbatmaxcellvoltage = 43;
     batteryConfig->vbatmincellvoltage = 33;
     batteryConfig->vbatwarningcellvoltage = 35;
+    batteryConfig->vbathysteresis = 1;
     batteryConfig->vbatPidCompensation = 0;
     batteryConfig->currentMeterOffset = 0;
     batteryConfig->currentMeterScale = 400; // for Allegro ACS758LCB-100U (40mV/A)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -634,6 +634,7 @@ const clivalue_t valueTable[] = {
     { "vbat_max_cell_voltage",      VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatmaxcellvoltage, .config.minmax = { 10,  50 } },
     { "vbat_min_cell_voltage",      VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatmincellvoltage, .config.minmax = { 10,  50 } },
     { "vbat_warning_cell_voltage",  VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatwarningcellvoltage, .config.minmax = { 10,  50 } },
+    { "vbat_hysteresis",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbathysteresis, .config.minmax = { 0,  250 } },
     { "vbat_pid_compensation",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.batteryConfig.vbatPidCompensation, .config.lookup = { TABLE_OFF_ON } },
     { "current_meter_scale",        VAR_INT16  | MASTER_VALUE,  &masterConfig.batteryConfig.currentMeterScale, .config.minmax = { -10000,  10000 } },
     { "current_meter_offset",       VAR_UINT16 | MASTER_VALUE,  &masterConfig.batteryConfig.currentMeterOffset, .config.minmax = { 0,  3300 } },

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -83,8 +83,6 @@ static void updateBatteryVoltage(void)
 }
 
 #define VBATTERY_STABLE_DELAY 40
-/* Batt Hysteresis of +/-100mV */
-#define VBATT_HYSTERESIS 1
 
 void updateBattery(void)
 {
@@ -123,23 +121,23 @@ void updateBattery(void)
     switch(batteryState)
     {
         case BATTERY_OK:
-            if (vbat <= (batteryWarningVoltage - VBATT_HYSTERESIS)) {
+            if (vbat <= (batteryWarningVoltage - batteryConfig->vbathysteresis)) {
                 batteryState = BATTERY_WARNING;
                 beeper(BEEPER_BAT_LOW);
             }
             break;
         case BATTERY_WARNING:
-            if (vbat <= (batteryCriticalVoltage - VBATT_HYSTERESIS)) {
+            if (vbat <= (batteryCriticalVoltage - batteryConfig->vbathysteresis)) {
                 batteryState = BATTERY_CRITICAL;
                 beeper(BEEPER_BAT_CRIT_LOW);
-            } else if (vbat > (batteryWarningVoltage + VBATT_HYSTERESIS)){
+            } else if (vbat > (batteryWarningVoltage + batteryConfig->vbathysteresis)){
                 batteryState = BATTERY_OK;
             } else {
                 beeper(BEEPER_BAT_LOW);
             }
             break;
         case BATTERY_CRITICAL:
-            if (vbat > (batteryCriticalVoltage + VBATT_HYSTERESIS)){
+            if (vbat > (batteryCriticalVoltage + batteryConfig->vbathysteresis)){
                 batteryState = BATTERY_WARNING;
                 beeper(BEEPER_BAT_LOW);
             } else {

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -40,6 +40,7 @@ typedef struct batteryConfig_s {
     uint8_t vbatmaxcellvoltage;             // maximum voltage per cell, used for auto-detecting battery voltage in 0.1V units, default is 43 (4.3V)
     uint8_t vbatmincellvoltage;             // minimum voltage per cell, this triggers battery critical alarm, in 0.1V units, default is 33 (3.3V)
     uint8_t vbatwarningcellvoltage;         // warning voltage per cell, this triggers battery warning alarm, in 0.1V units, default is 35 (3.5V)
+    uint8_t vbathysteresis;                 // hysteresis for alarm, default 1 = 0.1V
     uint8_t vbatPidCompensation;            // Scale PIDsum to battery voltage
 
     int16_t currentMeterScale;             // scale the current sensor output voltage to milliamps. Value in 1/10th mV/A


### PR DESCRIPTION
Adds a 'vbat_hysteresis = #' CLI parameter, where '#' is the battery-alarm-hysteresis value in 0.1V increments.  Default value is 1 (0.1V), which mirrors the previous behavior.  Setting "vbat_hysteresis=0" can reduce time-delay lag in the battery-alarm response, especially on 1S and 2S setups.

See #289 for previous PR on VBAT_HYSTERESIS.

--ET