### PR TITLE
Serial rx telemetry on same port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ COMMON_SRC = build_config.c \
 		   io/rc_curves.c \
 		   io/serial.c \
 		   io/serial_1wire.c \
+		   io/serial_1wire_vcp.c \
 		   io/serial_cli.c \
 		   io/serial_msp.c \
 		   io/statusindicator.c \

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -305,7 +305,7 @@ void resetSerialConfig(serialConfig_t *serialConfig)
 
 static void resetControlRateConfig(controlRateConfig_t *controlRateConfig) {
     controlRateConfig->rcRate8 = 100;
-    controlRateConfig->rcExpo8 = 20;
+    controlRateConfig->rcExpo8 = 60;
     controlRateConfig->thrMid8 = 50;
     controlRateConfig->thrExpo8 = 0;
     controlRateConfig->dynThrPID = 0;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -50,6 +50,7 @@ static pwmOutputPort_t *servos[MAX_PWM_SERVOS];
 
 static uint8_t allocatedOutputPortCount = 0;
 
+static bool pwmMotorsEnabled = true;
 static void pwmOCConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t value)
 {
     TIM_OCInitTypeDef  TIM_OCInitStructure;
@@ -163,7 +164,7 @@ static void pwmWriteMultiShot(uint8_t index, uint16_t value)
 
 void pwmWriteMotor(uint8_t index, uint16_t value)
 {
-    if (motors[index] && index < MAX_MOTORS)
+    if (motors[index] && index < MAX_MOTORS && pwmMotorsEnabled)
         motors[index]->pwmWritePtr(index, value);
 }
 
@@ -175,6 +176,16 @@ void pwmShutdownPulsesForAllMotors(uint8_t motorCount)
         // Set the compare register to 0, which stops the output pulsing if the timer overflows
         *motors[index]->ccr = 0;
     }
+}
+
+void pwmDisableMotors(void)
+{
+    pwmMotorsEnabled = false;
+}
+
+void pwmEnableMotors(void)
+{
+    pwmMotorsEnabled = true;
 }
 
 void pwmCompleteOneshotMotorUpdate(uint8_t motorCount)

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -183,3 +183,9 @@ serialPort_t *usbVcpOpen(void)
 
     return (serialPort_t *)s;
 }
+uint32_t usbVcpGetBaudRate(serialPort_t *instance)
+{
+    UNUSED(instance);
+
+    return CDC_BaudRate();
+}

--- a/src/main/drivers/serial_usb_vcp.h
+++ b/src/main/drivers/serial_usb_vcp.h
@@ -30,3 +30,4 @@ typedef struct {
 } vcpPort_t;
 
 serialPort_t *usbVcpOpen(void);
+uint32_t usbVcpGetBaudRate(serialPort_t *instance);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -205,10 +205,12 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         // -----calculate I component.
         errorGyroIf[axis] = constrainf(errorGyroIf[axis] + RateError * getdT() * pidProfile->I8[axis] / 10.0f, -250.0f, 250.0f);
 
+        if (IS_RC_MODE_ACTIVE(BOXSUPEREXPO) && axis != YAW) {
+            if (ABS(gyroRate) >= pidProfile->rollPitchItermResetRate) errorGyroIf[axis] = 0;
+        }
+
         if (axis == YAW) {
             if (ABS(gyroRate) >= pidProfile->yawItermResetRate) errorGyroIf[axis] = 0;
-        } else {
-            if (ABS(gyroRate) >= pidProfile->rollPitchItermResetRate) errorGyroIf[axis] = 0;
         }
 
         if (antiWindupProtection || motorLimitReached) {
@@ -490,10 +492,12 @@ static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *co
         // I coefficient (I8) moved before integration to make limiting independent from PID settings
         errorGyroI[axis] = constrain(errorGyroI[axis], (int32_t) - GYRO_I_MAX << 13, (int32_t) + GYRO_I_MAX << 13);
 
+        if (IS_RC_MODE_ACTIVE(BOXSUPEREXPO) && axis != YAW) {
+            if (ABS(gyroRate / 4) >= pidProfile->rollPitchItermResetRate) errorGyroI[axis] = 0;
+        }
+
         if (axis == YAW) {
             if (ABS(gyroRate / 4) >= pidProfile->yawItermResetRate) errorGyroI[axis] = 0;
-        } else {
-            if (ABS(gyroRate / 4) >= pidProfile->rollPitchItermResetRate) errorGyroI[axis] = 0;
         }
 
         if (antiWindupProtection || motorLimitReached) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -205,12 +205,10 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         // -----calculate I component.
         errorGyroIf[axis] = constrainf(errorGyroIf[axis] + RateError * getdT() * pidProfile->I8[axis] / 10.0f, -250.0f, 250.0f);
 
-        if (IS_RC_MODE_ACTIVE(BOXSUPEREXPO)) {
-            if (axis == YAW) {
-                if (ABS(gyroRate) >= pidProfile->yawItermResetRate) errorGyroIf[axis] = 0;
-            } else {
-                if (ABS(gyroRate) >= pidProfile->rollPitchItermResetRate) errorGyroIf[axis] = 0;
-            }
+        if (axis == YAW) {
+            if (ABS(gyroRate) >= pidProfile->yawItermResetRate) errorGyroIf[axis] = 0;
+        } else {
+            if (ABS(gyroRate) >= pidProfile->rollPitchItermResetRate) errorGyroIf[axis] = 0;
         }
 
         if (antiWindupProtection || motorLimitReached) {
@@ -492,12 +490,10 @@ static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *co
         // I coefficient (I8) moved before integration to make limiting independent from PID settings
         errorGyroI[axis] = constrain(errorGyroI[axis], (int32_t) - GYRO_I_MAX << 13, (int32_t) + GYRO_I_MAX << 13);
 
-        if (IS_RC_MODE_ACTIVE(BOXSUPEREXPO)) {
-            if (axis == YAW) {
-                if (ABS(gyroRate / 4) >= pidProfile->yawItermResetRate) errorGyroI[axis] = 0;
-            } else {
-                if (ABS(gyroRate / 4) >= pidProfile->rollPitchItermResetRate) errorGyroI[axis] = 0;
-            }
+        if (axis == YAW) {
+            if (ABS(gyroRate / 4) >= pidProfile->yawItermResetRate) errorGyroI[axis] = 0;
+        } else {
+            if (ABS(gyroRate / 4) >= pidProfile->rollPitchItermResetRate) errorGyroI[axis] = 0;
         }
 
         if (antiWindupProtection || motorLimitReached) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -60,7 +60,6 @@ int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 
 // PIDweight is a scale factor for PIDs which is derived from the throttle and TPA setting, and 100 = 100% scale means no PID reduction
 uint8_t dynP8[3], dynI8[3], dynD8[3], PIDweight[3];
-float tpaFactor;
 
 static int32_t errorGyroI[3], errorGyroILimit[3];
 static float errorGyroIf[3], errorGyroIfLimit[3];
@@ -136,6 +135,8 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
     float delta;
     int axis;
     float horizonLevelStrength = 1;
+
+    float tpaFactor = PIDweight[0] / 100.0f; // tpa is now float
 
     if (FLIGHT_MODE(HORIZON_MODE)) {
         // Figure out the raw stick positions

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -439,7 +439,7 @@ static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *co
         // -----Get the desired angle rate depending on flight mode
         if (axis == FD_YAW) {
             // YAW is always gyro-controlled (MAG correction is applied to rcCommand)
-            AngleRateTmp = ((int32_t)(rate + 27) * rcCommand[YAW]) >> 5;
+            AngleRateTmp = ((int32_t)(rate + 47) * rcCommand[YAW]) >> 5;
         } else {
             AngleRateTmp = ((int32_t)(rate + 27) * rcCommand[axis]) >> 4;
             if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) {

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -185,7 +185,6 @@ serialPort_t *findNextSharedSerialPort(uint16_t functionMask, serialPortFunction
     return NULL;
 }
 
-#define ALL_TELEMETRY_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_SMARTPORT | FUNCTION_TELEMETRY_LTM)
 #define ALL_FUNCTIONS_SHARABLE_WITH_MSP (FUNCTION_BLACKBOX | ALL_TELEMETRY_FUNCTIONS_MASK)
 
 bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
@@ -194,7 +193,8 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
     /*
      * rules:
      * - 1 MSP port minimum, max MSP ports is defined and must be adhered to.
-     * - Only MSP is allowed to be shared with EITHER any telemetry OR blackbox.
+     * - MSP is allowed to be shared with EITHER any telemetry OR blackbox.
+     * - serial RX and telemetry can be shared
      * - No other sharing combinations are valid.
      */
     uint8_t mspPortCount = 0;
@@ -214,12 +214,12 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
                 return false;
             }
 
-            if (!(portConfig->functionMask & FUNCTION_MSP)) {
-                return false;
-            }
-
-            if (!(portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP)) {
-                // some other bit must have been set.
+            if ((portConfig->functionMask & FUNCTION_MSP) && (portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP)) {
+                // MSP & telemetry
+            } else if (telemetryCheckRxPortShared(portConfig)) {
+                // serial RX & telemetry
+            } else {
+                // some other combination
                 return false;
             }
         }

--- a/src/main/io/serial_1wire.h
+++ b/src/main/io/serial_1wire.h
@@ -33,4 +33,5 @@ typedef struct {
 
 void usb1WireInitialize();
 void usb1WirePassthrough(uint8_t escIndex);
+void usb1WireDeInitialize(void);
 #endif

--- a/src/main/io/serial_1wire_vcp.c
+++ b/src/main/io/serial_1wire_vcp.c
@@ -1,0 +1,237 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author 4712
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "platform.h"
+
+#ifdef USE_SERIAL_1WIRE_VCP
+#include "drivers/gpio.h"
+#include "drivers/light_led.h"
+#include "drivers/system.h"
+#include "io/serial_1wire_vcp.h"
+#include "io/beeper.h"
+#include "drivers/pwm_mapping.h"
+#include "drivers/pwm_output.h"
+#include "flight/mixer.h"
+#include "io/serial_msp.h"
+#include "drivers/buf_writer.h"
+#include "drivers/serial_usb_vcp.h"
+
+uint8_t escCount;
+
+static escHardware_t escHardware[MAX_PWM_MOTORS];
+
+static uint32_t GetPinPos(uint32_t pin) {
+    uint32_t pinPos;
+    for (pinPos = 0; pinPos < 16; pinPos++) {
+        uint32_t pinMask = (0x1 << pinPos);
+        if (pin & pinMask) {
+            return pinPos;
+        }
+    }
+    return 0;
+}
+static uint8_t selected_esc;
+
+#define ESC_IS_HI   digitalIn(escHardware[selected_esc].gpio, escHardware[selected_esc].pin) != Bit_RESET
+#define ESC_IS_LO   digitalIn(escHardware[selected_esc].gpio, escHardware[selected_esc].pin) == Bit_RESET
+#define ESC_SET_HI  digitalHi(escHardware[selected_esc].gpio, escHardware[selected_esc].pin)
+#define ESC_SET_LO  digitalLo(escHardware[selected_esc].gpio, escHardware[selected_esc].pin)
+
+#define ESC_INPUT   gpioInit(escHardware[selected_esc].gpio, &escHardware[selected_esc].gpio_config_INPUT)
+#define ESC_OUTPUT  gpioInit(escHardware[selected_esc].gpio, &escHardware[selected_esc].gpio_config_OUTPUT)
+
+void usb1WireInitializeVcp(void)
+{
+    pwmDisableMotors();
+    selected_esc = 0;
+    memset(&escHardware, 0, sizeof(escHardware));
+    pwmOutputConfiguration_t *pwmOutputConfiguration = pwmGetOutputConfiguration();
+    for (volatile uint8_t i = 0; i < pwmOutputConfiguration->outputCount; i++) {
+      if ((pwmOutputConfiguration->portConfigurations[i].flags & PWM_PF_MOTOR) == PWM_PF_MOTOR) {
+          if(motor[pwmOutputConfiguration->portConfigurations[i].index] > 0) {
+              escHardware[selected_esc].gpio = pwmOutputConfiguration->portConfigurations[i].timerHardware->gpio;
+              escHardware[selected_esc].pin = pwmOutputConfiguration->portConfigurations[i].timerHardware->pin;
+              escHardware[selected_esc].pinpos = GetPinPos(escHardware[selected_esc].pin);
+              escHardware[selected_esc].gpio_config_INPUT.pin = escHardware[selected_esc].pin;
+              escHardware[selected_esc].gpio_config_INPUT.speed = Speed_2MHz; // see pwmOutConfig()
+              escHardware[selected_esc].gpio_config_INPUT.mode = Mode_IPU;
+              escHardware[selected_esc].gpio_config_OUTPUT = escHardware[selected_esc].gpio_config_INPUT;
+              escHardware[selected_esc].gpio_config_OUTPUT.mode = Mode_Out_PP;
+              ESC_INPUT;
+              ESC_SET_HI;
+              selected_esc++;
+          }
+      }
+    }
+    escCount = selected_esc;
+    selected_esc = 0;
+}
+
+void usb1WireDeInitializeVcp(void){
+    for (selected_esc = 0; selected_esc < (escCount); selected_esc++) {
+        escHardware[selected_esc].gpio_config_OUTPUT.mode = Mode_AF_PP; // see pwmOutConfig()
+        ESC_OUTPUT;
+        ESC_SET_LO;
+    }
+    escCount = 0;
+    pwmEnableMotors();
+}
+
+#define START_BIT_TIMEOUT_MS 2
+
+#define BIT_TIME (52)  //52uS
+#define BIT_TIME_HALVE (BIT_TIME >> 1) //26uS
+#define START_BIT_TIME (BIT_TIME_HALVE + 1)
+#define STOP_BIT_TIME ((BIT_TIME * 9) + BIT_TIME_HALVE)
+
+static void suart_putc_(uint8_t tx_b)
+{
+    uint32_t btime;
+    ESC_SET_LO; // 0 = start bit
+    btime = BIT_TIME + micros();
+    while (micros() < btime);
+    for(uint8_t bit = 0; bit <8; bit++)
+    {
+        if(tx_b & 1)
+        {
+            ESC_SET_HI; // 1
+        }
+        else
+        {
+            ESC_SET_LO; // 0
+        }
+        btime = btime + BIT_TIME;
+        tx_b = (tx_b >> 1);
+        while (micros() < btime);
+    }
+    ESC_SET_HI; // 1 = stop bit
+    btime = btime + BIT_TIME;
+    while (micros() < btime);
+}
+
+
+static uint8_t suart_getc_(uint8_t *bt)
+{
+    uint32_t btime;
+    uint32_t start_time;
+    uint32_t stop_time;
+    uint32_t wait_start;
+
+    *bt = 0;
+
+    wait_start = millis() + START_BIT_TIMEOUT_MS;
+    while (ESC_IS_HI) {
+        // check for start bit begin
+        if (millis() > wait_start) {
+            return 0;
+        }
+    }
+    // start bit
+    start_time = micros();
+    btime = start_time + START_BIT_TIME;
+    stop_time = start_time + STOP_BIT_TIME;
+
+    while (micros() < btime);
+
+    if (ESC_IS_HI) return 0; // check start bit
+    for (uint8_t bit=0;bit<8;bit++)
+    {
+        btime = btime + BIT_TIME;
+        while (micros() < btime);
+        if (ESC_IS_HI)
+        {
+             *bt |= (1 << bit); // 1 else 0
+        }
+    }
+    while (micros() < stop_time);
+
+    if (ESC_IS_LO) return 0;  // check stop bit
+
+    return 1; // OK
+}
+#define USE_TXRX_LED
+
+#ifdef  USE_TXRX_LED
+#define RX_LED_OFF LED0_OFF
+#define RX_LED_ON LED0_ON
+#ifdef  LED1
+#define TX_LED_OFF LED1_OFF
+#define TX_LED_ON LED1_ON
+#else
+#define TX_LED_OFF LED0_OFF
+#define TX_LED_ON LED0_ON
+#endif
+#else
+#define RX_LED_OFF
+#define RX_LED_ON
+#define TX_LED_OFF
+#define TX_LED_ON
+#endif
+
+// This method translates 2 wires (a tx and rx line) to 1 wire, by letting the
+// RX line control when data should be read or written from the single line
+void usb1WirePassthroughVcp(mspPort_t *mspPort, bufWriter_t *bufwriter, uint8_t escIndex)
+{
+#ifdef BEEPER
+    // fix for buzzer often starts beeping continuously when the ESCs are read
+    // switch beeper silent here
+    // TODO (4712) do we need beeperSilence()?
+    // beeperSilence();
+#endif
+
+    selected_esc = escIndex;
+    // TODO (4712) check all possible baud rate ok?
+    // uint32_t baudrate = serialGetBaudRate(mspPort->port);
+    // serialSetBaudRate(mspPort->port, 19200);
+
+    while(usbVcpGetBaudRate(mspPort->port) != 4800) {
+        // esc line is in Mode_IPU by default
+        static uint8_t bt;
+
+        if (suart_getc_(&bt)) {
+            RX_LED_ON;
+            serialBeginWrite(mspPort->port);
+            bufWriterAppend(bufwriter, bt);
+            while (suart_getc_(&bt)){
+               bufWriterAppend(bufwriter, bt);
+            }
+            serialEndWrite(mspPort->port);
+            bufWriterFlush(bufwriter);
+            RX_LED_OFF;
+        }
+        if (serialRxBytesWaiting(mspPort->port)) {
+            ESC_OUTPUT;
+            TX_LED_ON;
+            do {
+                bt = serialRead(mspPort->port);
+                suart_putc_(bt);
+            }  while(serialRxBytesWaiting(mspPort->port));
+            ESC_INPUT;
+            TX_LED_OFF;
+        }
+    }
+    // serialSetBaudRate(mspPort->port, baudrate);
+    return;
+}
+#endif
+

--- a/src/main/io/serial_1wire_vcp.h
+++ b/src/main/io/serial_1wire_vcp.h
@@ -13,16 +13,30 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author 4712
  */
-
 #pragma once
 
-void pwmWriteMotor(uint8_t index, uint16_t value);
-void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
-void pwmCompleteOneshotMotorUpdate(uint8_t motorCount);
+#include "platform.h"
+#ifdef USE_SERIAL_1WIRE_VCP
+#include "drivers/serial.h"
+#include "drivers/buf_writer.h"
+#include "drivers/pwm_mapping.h"
+#include "io/serial_msp.h"
 
-void pwmWriteServo(uint8_t index, uint16_t value);
+extern uint8_t escCount;
 
-bool isMotorBrushed(uint16_t motorPwmRate);
-void pwmDisableMotors(void);
-void pwmEnableMotors(void);
+typedef struct {
+    GPIO_TypeDef* gpio;
+    uint16_t pinpos;
+    uint16_t pin;
+    gpio_config_t gpio_config_INPUT;
+    gpio_config_t gpio_config_OUTPUT;
+} escHardware_t;
+
+void usb1WireInitializeVcp(void);
+void usb1WireDeInitializeVcp(void);
+void usb1WirePassthroughVcp(mspPort_t *mspPort, bufWriter_t *bufwriter, uint8_t escIndex);
+#endif
+

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -731,7 +731,7 @@ const clivalue_t valueTable[] = {
     { "dterm_average_count",        VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_average_count, .config.minmax = {0, 12 } },
     { "iterm_reset_degrees",        VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.rollPitchItermResetRate, .config.minmax = {50, 1000 } },
     { "yaw_iterm_reset_degrees",    VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yawItermResetRate, .config.minmax = {25, 1000 } },
-    { "yaw_lowpass_hz",             VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
+    { "yaw_lowpass_hz",             VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yaw_lpf_hz, .config.minmax = {0, 500 } },
     { "pid_process_denom",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.pid_process_denom, .config.minmax = { 1,  8 } },
 
     { "pid_controller",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.pidController, .config.lookup = { TABLE_PID_CONTROLLER } },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -727,11 +727,11 @@ const clivalue_t valueTable[] = {
     { "mag_hardware",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.mag_hardware, .config.lookup = { TABLE_MAG_HARDWARE } },
     { "mag_declination",            VAR_INT16  | MASTER_VALUE, &masterConfig.mag_declination, .config.minmax = { -18000,  18000 } },
     { "pid_delta_method",           VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.deltaMethod, .config.lookup = { TABLE_DELTA_METHOD } },
-    { "dterm_lowpass_hz",               VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
+    { "dterm_lowpass_hz",           VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
     { "dterm_average_count",        VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_average_count, .config.minmax = {0, 12 } },
     { "iterm_reset_degrees",        VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.rollPitchItermResetRate, .config.minmax = {50, 1000 } },
     { "yaw_iterm_reset_degrees",    VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yawItermResetRate, .config.minmax = {25, 1000 } },
-    { "yaw_lowpass_hz",                 VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
+    { "yaw_lowpass_hz",             VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
     { "pid_process_denom",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.pid_process_denom, .config.minmax = { 1,  8 } },
 
     { "pid_controller",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.pidController, .config.lookup = { TABLE_PID_CONTROLLER } },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -660,7 +660,7 @@ const clivalue_t valueTable[] = {
 
     { "gyro_lpf",                   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.gyro_lpf, .config.lookup = { TABLE_GYRO_LPF } },
     { "gyro_sync_denom",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.gyro_sync_denom, .config.minmax = { 1,  8 } },
-    { "gyro_soft_lpf",              VAR_FLOAT  | MASTER_VALUE,  &masterConfig.gyro_soft_lpf_hz, .config.minmax = { 0,  500 } },
+    { "gyro_lowpass_hz",            VAR_FLOAT  | MASTER_VALUE,  &masterConfig.gyro_soft_lpf_hz, .config.minmax = { 0,  500 } },
     { "moron_threshold",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.gyroConfig.gyroMovementCalibrationThreshold, .config.minmax = { 0,  128 } },
     { "imu_dcm_kp",                 VAR_UINT16 | MASTER_VALUE,  &masterConfig.dcm_kp, .config.minmax = { 0,  50000 } },
     { "imu_dcm_ki",                 VAR_UINT16 | MASTER_VALUE,  &masterConfig.dcm_ki, .config.minmax = { 0,  50000 } },
@@ -727,11 +727,11 @@ const clivalue_t valueTable[] = {
     { "mag_hardware",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.mag_hardware, .config.lookup = { TABLE_MAG_HARDWARE } },
     { "mag_declination",            VAR_INT16  | MASTER_VALUE, &masterConfig.mag_declination, .config.minmax = { -18000,  18000 } },
     { "pid_delta_method",           VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.deltaMethod, .config.lookup = { TABLE_DELTA_METHOD } },
-    { "dterm_lpf_hz",               VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
+    { "dterm_lowpass_hz",               VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
     { "dterm_average_count",        VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_average_count, .config.minmax = {0, 12 } },
     { "iterm_reset_degrees",        VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.rollPitchItermResetRate, .config.minmax = {50, 1000 } },
     { "yaw_iterm_reset_degrees",    VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yawItermResetRate, .config.minmax = {25, 1000 } },
-    { "yaw_lpf_hz",                 VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
+    { "yaw_lowpass_hz",                 VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_lpf_hz, .config.minmax = {0, 500 } },
     { "pid_process_denom",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.pid_process_denom, .config.minmax = { 1,  8 } },
 
     { "pid_controller",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.pidController, .config.lookup = { TABLE_PID_CONTROLLER } },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1999,7 +1999,7 @@ void cliDumpProfile(uint8_t profileIndex) {
         changeProfile(profileIndex);
         cliPrint("\r\n# profile\r\n");
         cliProfile("");
-        cliPrintf("############################# PROFILE VALUES ####################################");
+        cliPrintf("############################# PROFILE VALUES ####################################\r\n");
         cliProfile("");
         printSectionBreak();
         dumpValues(PROFILE_VALUE);

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -96,6 +96,9 @@
 #ifdef USE_SERIAL_1WIRE
 #include "io/serial_1wire.h"
 #endif
+#ifdef USE_SERIAL_1WIRE_VCP
+#include "io/serial_1wire_vcp.h"
+#endif
 #ifdef USE_ESCSERIAL
 #include "drivers/serial_escserial.h"
 #endif
@@ -1751,61 +1754,105 @@ static bool processInCommand(void)
             // switch all motor lines HI
             usb1WireInitialize();
             // reply the count of ESC found
-            headSerialReply(1);
+            headSerialReply(2);
             serialize8(escCount);
-
+            serialize8(currentPort->port->identifier);
             // and come back right afterwards
             // rem: App: Wait at least appx. 500 ms for BLHeli to jump into
             // bootloader mode before try to connect any ESC
 
             return true;
-        }
-        else {
+        } else if (i < escCount) {
             // Check for channel number 0..ESC_COUNT-1
-            if (i < escCount) {
-                // because we do not come back after calling usb1WirePassthrough
-                // proceed with a success reply first
-                headSerialReply(0);
-                tailSerialReply();
-                // flush the transmit buffer
-                bufWriterFlush(writer);
-                // wait for all data to send
-                waitForSerialPortToFinishTransmitting(currentPort->port);
-                // Start to activate here
-                // motor 1 => index 0
+            // because we do not come back after calling usb1WirePassthrough
+            // proceed with a success reply first
+            headSerialReply(0);
+            tailSerialReply();
+            // flush the transmit buffer
+            bufWriterFlush(writer);
+            // wait for all data to send
+            waitForSerialPortToFinishTransmitting(currentPort->port);
+            // Start to activate here
+            // motor 1 => index 0
 
-                // search currentPort portIndex
-                /* next lines seems to be unnecessary, because the currentPort always point to the same mspPorts[portIndex]
-                uint8_t portIndex;
-				for (portIndex = 0; portIndex < MAX_MSP_PORT_COUNT; portIndex++) {
-					if (currentPort == &mspPorts[portIndex]) {
-						break;
-					}
-				}
-				*/
-                mspReleasePortIfAllocated(mspSerialPort); // CloseSerialPort also marks currentPort as UNUSED_PORT
-                usb1WirePassthrough(i);
-                // Wait a bit more to let App read the 0 byte and switch baudrate
-                // 2ms will most likely do the job, but give some grace time
-                delay(10);
-                // rebuild/refill currentPort structure, does openSerialPort if marked UNUSED_PORT - used ports are skiped
-                mspAllocateSerialPorts(&masterConfig.serialConfig);
-                /* restore currentPort and mspSerialPort
-                setCurrentPort(&mspPorts[portIndex]); // not needed same index will be restored
-                */
-                // former used MSP uart is active again
-                // restore MSP_SET_1WIRE as current command for correct headSerialReply(0)
-                currentPort->cmdMSP = MSP_SET_1WIRE;
-            } else {
-                // ESC channel higher than max. allowed
-                // rem: BLHeliSuite will not support more than 8
-                headSerialError(0);
+            // search currentPort portIndex
+            /* next lines seems to be unnecessary, because the currentPort always point to the same mspPorts[portIndex]
+            uint8_t portIndex;
+            for (portIndex = 0; portIndex < MAX_MSP_PORT_COUNT; portIndex++) {
+                if (currentPort == &mspPorts[portIndex]) {
+                    break;
+                }
             }
+            */
+            // *mspReleasePortIfAllocated(mspSerialPort); // CloseSerialPort also marks currentPort as UNUSED_PORT
+            usb1WirePassthrough(i);
+            // Wait a bit more to let App read the 0 byte and/or switch baudrate
+            // 2ms will most likely do the job, but give some grace time
+            delay(10);
+            // rebuild/refill currentPort structure, does openSerialPort if marked UNUSED_PORT - used ports are skiped
+            // *mspAllocateSerialPorts(&masterConfig.serialConfig);
+            /* restore currentPort and mspSerialPort
+            setCurrentPort(&mspPorts[portIndex]); // not needed same index will be restored
+            */
+            // former used MSP uart is active again
+            // restore MSP_SET_1WIRE as current command for correct headSerialReply(0)
+            //currentPort->cmdMSP = MSP_SET_1WIRE;
+        } else if (i == 0xFE) {
+               usb1WireDeInitialize();
+        } else {
+           // ESC channel higher than max. allowed
+           headSerialError(0);
+        }
+        // proceed as usual with MSP commands
+        // and wait to switch to next channel
+        // rem: App needs to call MSP_BOOT to deinitialize Passthrough
+        break;
+#endif
+
+#ifdef USE_SERIAL_1WIRE_VCP
+    case MSP_SET_1WIRE:
+        // get channel number
+        i = read8();
+        // we do not give any data back, assume channel number is transmitted OK
+        if (i == 0xFF) {
+            // 0xFF -> preinitialize the Passthrough
+            // switch all motor lines HI
+            usb1WireInitializeVcp();
+            // reply the count of ESC found
+            headSerialReply(2);
+            serialize8(escCount);
+            serialize8(currentPort->port->identifier);
+            // and come back right afterwards
+            // rem: App: Wait at least appx. 500 ms for BLHeli to jump into
+            // bootloader mode before try to connect any ESC
+
+            return true;
+        } else if (i < escCount) {
+            // Check for channel number 0..ESC_COUNT-1
+            // because we do not come back after calling usb1WirePassthrough
+            // proceed with a success reply first
+            headSerialReply(0);
+            tailSerialReply();
+            // flush the transmit buffer
+            bufWriterFlush(writer);
+            // wait for all data to send
+            waitForSerialPortToFinishTransmitting(currentPort->port);
+            // Start to activate here
+            // motor 1 => index 0
+            usb1WirePassthroughVcp(currentPort, writer, i);
+            // Wait a bit more to let App switch baudrate
+            delay(10);
+            // former used MSP uart is still active
             // proceed as usual with MSP commands
             // and wait to switch to next channel
-            // rem: App needs to call MSP_BOOT to deinitialize Passthrough
+            // rem: App needs to call MSP_SET_1WIRE(0xFE) to deinitialize Passthrough
+        } else if (i == 0xFE) {
+            usb1WireDeInitializeVcp();
+        } else {
+            // ESC channel higher than max. allowed
+            headSerialError(0);
         }
-        break;
+    break;
 #endif
 
 #ifdef USE_ESCSERIAL

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -113,7 +113,6 @@ static uint32_t disarmAt;     // Time of automatic disarm when "Don't spin the m
 
 extern uint32_t currentTime;
 extern uint8_t dynP8[3], dynI8[3], dynD8[3], PIDweight[3];
-extern float tpaFactor;
 extern bool antiWindupProtection;
 
 uint16_t filteredCycleTime;
@@ -233,7 +232,6 @@ void annexCode(void)
             prop2 = 100 - (uint16_t)currentControlRateProfile->dynThrPID * (rcData[THROTTLE] - currentControlRateProfile->tpa_breakpoint) / (2000 - currentControlRateProfile->tpa_breakpoint);
         } else {
             prop2 = 100 - currentControlRateProfile->dynThrPID;
-            tpaFactor = prop2 / 100.0f;
         }
     }
 

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -366,8 +366,11 @@ void releaseSharedTelemetryPorts(void) {
 
 void mwArm(void)
 {
-    if (!ARMING_FLAG(WAS_EVER_ARMED) && masterConfig.gyro_cal_on_first_arm) {
-	    gyroSetCalibrationCycles(calculateCalibratingCycles());
+    static bool armingCalibrationWasInitialisedOnce;
+
+    if (masterConfig.gyro_cal_on_first_arm && !armingCalibrationWasInitialisedOnce) {
+        gyroSetCalibrationCycles(calculateCalibratingCycles());
+        armingCalibrationWasInitialisedOnce = true;
     }
 
     if (!isGyroCalibrationComplete()) return;  // prevent arming before gyro is calibrated

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -29,6 +29,8 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#include "telemetry/telemetry.h"
+
 #include "rx/rx.h"
 #include "rx/ibus.h"
 
@@ -60,7 +62,13 @@ bool ibusInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRa
         return false;
     }
 
-    serialPort_t *ibusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, ibusDataReceive, IBUS_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+
+    serialPort_t *ibusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, ibusDataReceive, IBUS_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+    if (portShared) {
+        telemetrySharedPort = ibusPort;
+    }
 
     return ibusPort != NULL;
 }

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -32,6 +32,8 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#include "telemetry/telemetry.h"
+
 #include "rx/rx.h"
 #include "rx/sbus.h"
 
@@ -92,8 +94,14 @@ bool sbusInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRa
         return false;
     }
 
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+
     portOptions_t options = (rxConfig->sbus_inversion) ? (SBUS_PORT_OPTIONS | SERIAL_INVERTED) : SBUS_PORT_OPTIONS;
-    serialPort_t *sBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sbusDataReceive, SBUS_BAUDRATE, MODE_RX, options);
+    serialPort_t *sBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sbusDataReceive, SBUS_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, options);
+
+    if (portShared) {
+        telemetrySharedPort = sBusPort;
+    }
 
     return sBusPort != NULL;
 }

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -33,6 +33,8 @@
 
 #include "config/config.h"
 
+#include "telemetry/telemetry.h"
+
 #include "rx/rx.h"
 #include "rx/spektrum.h"
 
@@ -87,7 +89,13 @@ bool spektrumInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcRe
         return false;
     }
 
-    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+
+    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+    if (portShared) {
+        telemetrySharedPort = spektrumPort;
+    }
 
     return spektrumPort != NULL;
 }

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -29,6 +29,8 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#include "telemetry/telemetry.h"
+
 #include "rx/rx.h"
 #include "rx/sumd.h"
 
@@ -63,7 +65,13 @@ bool sumdInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRa
         return false;
     }
 
-    serialPort_t *sumdPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumdDataReceive, SUMD_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+
+    serialPort_t *sumdPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumdDataReceive, SUMD_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+    if (portShared) {
+        telemetrySharedPort = sumdPort;
+    }
 
     return sumdPort != NULL;
 }

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -35,6 +35,8 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#include "telemetry/telemetry.h"
+
 #include "rx/rx.h"
 #include "rx/sumh.h"
 
@@ -75,7 +77,13 @@ bool sumhInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRa
         return false;
     }
 
-    sumhPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumhDataReceive, SUMH_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+
+    sumhPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumhDataReceive, SUMH_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+    if (portShared) {
+        telemetrySharedPort = sumhPort;
+    }
 
     return sumhPort != NULL;
 }

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -27,6 +27,8 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#include "telemetry/telemetry.h"
+
 #include "rx/rx.h"
 #include "rx/xbus.h"
 
@@ -123,7 +125,13 @@ bool xBusInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRa
         return false;
     }
 
-    serialPort_t *xBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, xBusDataReceive, baudRate, MODE_RX, SERIAL_NOT_INVERTED);
+    bool portShared = telemetryCheckRxPortShared(portConfig);
+
+    serialPort_t *xBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, xBusDataReceive, baudRate, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+    if (portShared) {
+        telemetrySharedPort = xBusPort;
+    }
 
     return xBusPort != NULL;
 }

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -126,8 +126,13 @@
 #define USE_SERVOS
 #define USE_CLI
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 // FlexPort (pin 21/22, TX/RX respectively):
 // Note, FlexPort has 10k pullups on both TX and RX
 // JST Pin3 TX - connect to external UART/USB RX
@@ -136,6 +141,7 @@
 // JST Pin4 RX - connect to external UART/USB TX
 #define S1W_RX_GPIO         GPIOB
 #define S1W_RX_PIN          GPIO_Pin_11
+#endif
 
 #undef DISPLAY
 #undef SONAR

--- a/src/main/target/COLIBRI_RACE/target.h
+++ b/src/main/target/COLIBRI_RACE/target.h
@@ -184,8 +184,14 @@
 #define USE_SERVOS
 #define USE_CLI
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         GPIOB
 #define S1W_TX_PIN          GPIO_Pin_10
 #define S1W_RX_GPIO         GPIOB
 #define S1W_RX_PIN          GPIO_Pin_11
+#endif

--- a/src/main/target/IRCFUSIONF3/target.h
+++ b/src/main/target/IRCFUSIONF3/target.h
@@ -165,8 +165,16 @@
 #define BIND_PORT  GPIOB
 #define BIND_PIN   Pin_11
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         GPIOA
 #define S1W_TX_PIN          GPIO_Pin_9
 #define S1W_RX_GPIO         GPIOA
 #define S1W_RX_PIN          GPIO_Pin_10
+#endif
+
+

--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -165,9 +165,15 @@
 #define BIND_PORT  GPIOC
 #define BIND_PIN   Pin_5
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
+#ifdef USE_SERIAL_1WIRE
 // Untested
 #define S1W_TX_GPIO         GPIOB
 #define S1W_TX_PIN          GPIO_Pin_10
 #define S1W_RX_GPIO         GPIOB
 #define S1W_RX_PIN          GPIO_Pin_11
+#endif

--- a/src/main/target/MOTOLAB/target.h
+++ b/src/main/target/MOTOLAB/target.h
@@ -191,10 +191,15 @@
 #define BIND_PORT GPIOB
 #define BIND_PIN Pin_4
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         GPIOB
 #define S1W_TX_PIN          GPIO_Pin_6
 #define S1W_RX_GPIO         GPIOB
 #define S1W_RX_PIN          GPIO_Pin_7
-
+#endif

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -191,14 +191,20 @@
 #define BIND_PORT  GPIOA
 #define BIND_PIN   Pin_3
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 // STM32F103CBT6-LQFP48 Pin30 (PA9) TX - PC3 connects to onboard CP2102 RX
 #define S1W_TX_GPIO         GPIOA
 #define S1W_TX_PIN          GPIO_Pin_9
 // STM32F103CBT6-LQFP48 Pin31 (PA10) RX - PC1 to onboard CP2102 TX
 #define S1W_RX_GPIO         GPIOA
 #define S1W_RX_PIN          GPIO_Pin_10
+#endif
 
 // alternative defaults for AlienWii32 F1 target
 #ifdef ALIENWII32

--- a/src/main/target/PORT103R/target.h
+++ b/src/main/target/PORT103R/target.h
@@ -156,3 +156,15 @@
 #define TELEMETRY
 #define USE_SERVOS
 #define USE_CLI
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
+#define USE_SERIAL_1WIRE
+#endif
+
+#ifdef USE_SERIAL_1WIRE
+#define S1W_TX_GPIO         GPIOA
+#define S1W_TX_PIN          GPIO_Pin_9
+#define S1W_RX_GPIO         GPIOA
+#define S1W_RX_PIN          GPIO_Pin_10
+#endif

--- a/src/main/target/RMDO/target.h
+++ b/src/main/target/RMDO/target.h
@@ -157,9 +157,15 @@
 #define BIND_PORT  GPIOB
 #define BIND_PIN   Pin_11
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         GPIOA
 #define S1W_TX_PIN          GPIO_Pin_9
 #define S1W_RX_GPIO         GPIOA
 #define S1W_RX_PIN          GPIO_Pin_10
+#endif

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -166,12 +166,18 @@
 #define WS2811_IRQ                      DMA1_Channel7_IRQn
 #endif
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         GPIOB
 #define S1W_TX_PIN          GPIO_Pin_6
 #define S1W_RX_GPIO         GPIOB
 #define S1W_RX_PIN          GPIO_Pin_7
+#endif
 
 #define SPEKTRUM_BIND
 // USART2, PA3

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -165,9 +165,15 @@
 #define BIND_PORT  GPIOB
 #define BIND_PIN   Pin_11
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         GPIOA
 #define S1W_TX_PIN          GPIO_Pin_9
 #define S1W_RX_GPIO         GPIOA
 #define S1W_RX_PIN          GPIO_Pin_10
+#endif

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -234,9 +234,15 @@
 #define BINDPLUG_PORT  BUTTON_B_PORT
 #define BINDPLUG_PIN   BUTTON_B_PIN
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
+#endif
 
+#ifdef USE_SERIAL_1WIRE
 #define S1W_TX_GPIO         UART1_GPIO
 #define S1W_TX_PIN          UART1_TX_PIN
 #define S1W_RX_GPIO         UART1_GPIO
 #define S1W_RX_PIN          UART1_RX_PIN
+#endif

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -162,12 +162,17 @@
 #define USE_SERVOS
 #define USE_CLI
 
+#ifdef USE_VCP
+#define USE_SERIAL_1WIRE_VCP
+#else
 #define USE_SERIAL_1WIRE
-// How many escs does this board support?
-#define ESC_COUNT 6
+#endif
+
+#ifdef USE_SERIAL_1WIRE
 // STM32F3DISCOVERY TX - PD5 connects to UART RX
 #define S1W_TX_GPIO         GPIOD
 #define S1W_TX_PIN          GPIO_Pin_5
 // STM32F3DISCOVERY RX - PD6 connects to UART TX
 #define S1W_RX_GPIO         GPIOD
 #define S1W_RX_PIN          GPIO_Pin_6
+#endif

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -477,16 +477,23 @@ static inline bool shouldCheckForHoTTRequest()
 
 void checkHoTTTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(hottPortSharing);
+    if (portConfig && telemetryCheckRxPortShared(portConfig)) {
+        if (!hottTelemetryEnabled && telemetrySharedPort != NULL) {
+            hottPort = telemetrySharedPort;
+            hottTelemetryEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(hottPortSharing);
 
-    if (newTelemetryEnabledValue == hottTelemetryEnabled) {
-        return;
+        if (newTelemetryEnabledValue == hottTelemetryEnabled) {
+            return;
+        }
+
+        if (newTelemetryEnabledValue)
+            configureHoTTTelemetryPort();
+        else
+            freeHoTTTelemetryPort();
     }
-
-    if (newTelemetryEnabledValue)
-        configureHoTTTelemetryPort();
-    else
-        freeHoTTTelemetryPort();
 }
 
 void handleHoTTTelemetry(void)

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -298,12 +298,19 @@ void configureLtmTelemetryPort(void)
 
 void checkLtmTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(ltmPortSharing);
-    if (newTelemetryEnabledValue == ltmEnabled)
-        return;
-    if (newTelemetryEnabledValue)
-        configureLtmTelemetryPort();
-    else
-        freeLtmTelemetryPort();
+    if (portConfig && telemetryCheckRxPortShared(portConfig)) {
+        if (!ltmEnabled && telemetrySharedPort != NULL) {
+            ltmPort = telemetrySharedPort;
+            ltmEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(ltmPortSharing);
+        if (newTelemetryEnabledValue == ltmEnabled)
+            return;
+        if (newTelemetryEnabledValue)
+            configureLtmTelemetryPort();
+        else
+            freeLtmTelemetryPort();
+    }
 }
 #endif

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -259,16 +259,23 @@ bool isSmartPortTimedOut(void)
 
 void checkSmartPortTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(smartPortPortSharing);
+    if (portConfig && telemetryCheckRxPortShared(portConfig)) {
+        if (!smartPortTelemetryEnabled && telemetrySharedPort != NULL) {
+            smartPortSerialPort = telemetrySharedPort;
+            smartPortTelemetryEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(smartPortPortSharing);
 
-    if (newTelemetryEnabledValue == smartPortTelemetryEnabled) {
-        return;
+        if (newTelemetryEnabledValue == smartPortTelemetryEnabled) {
+            return;
+        }
+
+        if (newTelemetryEnabledValue)
+            configureSmartPortTelemetryPort();
+        else
+            freeSmartPortTelemetryPort();
     }
-
-    if (newTelemetryEnabledValue)
-        configureSmartPortTelemetryPort();
-    else
-        freeSmartPortTelemetryPort();
 }
 
 void handleSmartPortTelemetry(void)

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -74,6 +74,13 @@ bool telemetryDetermineEnabledState(portSharing_e portSharing)
     return enabled;
 }
 
+bool telemetryCheckRxPortShared(serialPortConfig_t *portConfig)
+{
+    return portConfig->functionMask & FUNCTION_RX_SERIAL && portConfig->functionMask & ALL_TELEMETRY_FUNCTIONS_MASK;
+}
+
+serialPort_t *telemetrySharedPort = NULL;
+
 void telemetryCheckState(void)
 {
     checkFrSkyTelemetryState();

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -48,11 +48,16 @@ typedef struct telemetryConfig_s {
     uint8_t hottAlarmSoundInterval;
 } telemetryConfig_t;
 
+bool telemetryCheckRxPortShared(serialPortConfig_t *portConfig);
+extern serialPort_t *telemetrySharedPort;
+
 void telemetryCheckState(void);
 void telemetryProcess(rxConfig_t *rxConfig, uint16_t deadband3d_throttle);
 
 bool telemetryDetermineEnabledState(portSharing_e portSharing);
 
 void telemetryUseConfig(telemetryConfig_t *telemetryConfig);
+
+#define ALL_TELEMETRY_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_SMARTPORT | FUNCTION_TELEMETRY_LTM)
 
 #endif /* TELEMETRY_COMMON_H_ */

--- a/src/main/vcp/hw_config.c
+++ b/src/main/vcp/hw_config.c
@@ -362,4 +362,17 @@ uint8_t usbIsConnected(void)
     return (bDeviceState != UNCONNECTED);
 }
 
+
+/*******************************************************************************
+ * Function Name  : CDC_BaudRate.
+ * Description    : Get the current baud rate
+ * Input          : None.
+ * Output         : None.
+ * Return         : Baud rate in bps
+ *******************************************************************************/
+uint32_t CDC_BaudRate(void)
+{
+    return Virtual_Com_Port_GetBaudRate();
+}
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/main/vcp/hw_config.h
+++ b/src/main/vcp/hw_config.h
@@ -59,6 +59,7 @@ uint32_t CDC_Send_DATA(uint8_t *ptrBuffer, uint8_t sendLength);  // HJI
 uint32_t CDC_Receive_DATA(uint8_t* recvBuf, uint32_t len);       // HJI
 uint8_t usbIsConfigured(void);  // HJI
 uint8_t usbIsConnected(void);   // HJI
+uint32_t CDC_BaudRate(void);
 /* External variables --------------------------------------------------------*/
 
 extern __IO uint32_t receiveLength;  // HJI

--- a/src/main/vcp/usb_prop.c
+++ b/src/main/vcp/usb_prop.c
@@ -358,5 +358,17 @@ uint8_t *Virtual_Com_Port_SetLineCoding(uint16_t Length)
     return (uint8_t *)&linecoding;
 }
 
+/*******************************************************************************
+ * Function Name  : Virtual_Com_Port_GetBaudRate.
+ * Description    : Get the current baudrate
+ * Input          : None.
+ * Output         : None.
+ * Return         : baudrate in bps
+ *******************************************************************************/
+uint32_t Virtual_Com_Port_GetBaudRate(void)
+{
+    return linecoding.bitrate;
+}
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/src/main/vcp/usb_prop.h
+++ b/src/main/vcp/usb_prop.h
@@ -79,6 +79,7 @@ uint8_t *Virtual_Com_Port_GetStringDescriptor( uint16_t);
 uint8_t *Virtual_Com_Port_GetLineCoding(uint16_t Length);
 uint8_t *Virtual_Com_Port_SetLineCoding(uint16_t Length);
 
+uint32_t Virtual_Com_Port_GetBaudRate(void);
 #endif /* __usb_prop_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
This PR enables sharing of one serial port between serial RX and telemetry. If a port is shared, the speed and inversion settings of the port are dictated by the serial RX protocol used, and any settings for the telemetry protocol are ignored. As a consequence, this will only work if the RX can receive telemetry data at the same speed as the serial RX data it is set to output.

This has only been tested (and found to work fine) with a Naze32 rev 6 as the FC, and an OrangeRx openLRS RX. The combination of SUMD RX and FrSky telemetry over the same serial port works fine with this hardware.

Any feedback on other combinations working / not working is appreciated, and will be integrated.