### PR TITLE
Enable CLI dump / restore of multiple profiles without buffer overrun

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1986,6 +1986,7 @@ void cliDumpProfile(uint8_t profileIndex) {
         changeProfile(profileIndex);
         cliPrint("\r\n# profile\r\n");
         cliProfile("");
+        cliPrintf("################################################################################");
         printSectionBreak();
         dumpValues(PROFILE_VALUE);
         uint8_t currentRateIndex = currentProfile->activeRateProfile;


### PR DESCRIPTION
I've added printing of a line of '#' after every profile switch that is executed during the restore of a CLI profile dump.
When the serial buffer is overrun during the profile switch (as it usually does), some characters of this line are lost. This does not have a negative impact, as the rest of the line is interpreted as a comment.