### PR TITLE
Send averaged cell voltage on A4

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -83,7 +83,7 @@ enum
     // remaining 3 bits are crc (according to comments in openTx code)
 };
 
-// these data identifiers are obtained from http://diydrones.com/forum/topics/amp-to-frsky-x8r-sport-converter
+// these data identifiers are obtained from https://github.com/opentx/opentx/blob/master/radio/src/telemetry/frsky.h
 enum
 {
     FSSP_DATAID_SPEED      = 0x0830 ,
@@ -106,6 +106,8 @@ enum
     FSSP_DATAID_T1         = 0x0400 ,
     FSSP_DATAID_T2         = 0x0410 ,
     FSSP_DATAID_GPS_ALT    = 0x0820 ,
+    FSSP_DATAID_A3         = 0x0900 ,
+    FSSP_DATAID_A4         = 0x0910 ,
 };
 
 const uint16_t frSkyDataIdTable[] = {
@@ -130,6 +132,7 @@ const uint16_t frSkyDataIdTable[] = {
     FSSP_DATAID_T1        ,
     FSSP_DATAID_T2        ,
     FSSP_DATAID_GPS_ALT   ,
+    FSSP_DATAID_A4        ,
     0
 };
 
@@ -471,6 +474,12 @@ void handleSmartPortTelemetry(void)
                 }
                 break;
 #endif
+            case FSSP_DATAID_A4         :
+                if (feature(FEATURE_VBAT)) {
+                    smartPortSendPackage(id, vbat * 10 / batteryCellCount ); // given in 0.1V, convert to volts
+                    smartPortHasRequest = 0;
+                }
+                break;
             default:
                 break;
                 // if nothing is sent, smartPortHasRequest isn't cleared, we already incremented the counter, just loop back to the start


### PR DESCRIPTION
Basically a copy of https://github.com/cleanflight/cleanflight/pull/1963 which enable to receive vfas voltage and averaged cell voltage at the same time.