### PR TITLE
Blackbox Logging enhancements

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1183,12 +1183,15 @@ static bool blackboxWriteSysinfo()
             blackboxPrintfHeaderLine("rcYawExpo:%d", masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rcYawExpo8);
             break;
         case 15:
+            blackboxPrintfHeaderLine("superExpoFactor:%d", masterConfig.rxConfig.superExpoFactor);
+            break;
+        case 16:
             blackboxPrintfHeaderLine("rates:%d,%d,%d",
                                      masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rates[0],
                                      masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rates[1],
                                      masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rates[2]);
             break;
-        case 16:
+        case 17:
             blackboxPrintfHeaderLine("looptime:%d", targetLooptime);
             break;
         default:

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -323,6 +323,9 @@ extern uint32_t currentTime;
 //From rx.c:
 extern uint16_t rssi;
 
+//From gyro.c
+extern uint32_t targetLooptime;
+
 static BlackboxState blackboxState = BLACKBOX_STATE_DISABLED;
 
 static uint32_t blackboxLastArmingBeep = 0;
@@ -1166,6 +1169,21 @@ static bool blackboxWriteSysinfo()
                 blackboxPrintfHeaderLine("currentMeter:%d,%d", masterConfig.batteryConfig.currentMeterOffset, masterConfig.batteryConfig.currentMeterScale);
             }
         break;
+        case 13:
+            blackboxPrintfHeaderLine("rcExpo:%d", masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rcExpo8);
+            break;
+        case 14:
+            blackboxPrintfHeaderLine("rcYawExpo:%d", masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rcYawExpo8);
+            break;
+        case 15:
+            blackboxPrintfHeaderLine("rates:%d,%d,%d",
+                                     masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rates[0],
+                                     masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rates[1],
+                                     masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].rates[2]);
+            break;
+        case 16:
+            blackboxPrintfHeaderLine("looptime:%d", targetLooptime);
+            break;
         default:
             return true;
     }

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -106,12 +106,18 @@ typedef enum FlightLogEvent {
     FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT = 13,
     FLIGHT_LOG_EVENT_LOGGING_RESUME = 14,
     FLIGHT_LOG_EVENT_GTUNE_RESULT = 20,
+    FLIGHT_LOG_EVENT_FLIGHTMODE = 30, // Add new event type for flight mode status.
     FLIGHT_LOG_EVENT_LOG_END = 255
 } FlightLogEvent;
 
 typedef struct flightLogEvent_syncBeep_s {
     uint32_t time;
 } flightLogEvent_syncBeep_t;
+
+typedef struct flightLogEvent_flightMode_s { // New Event Data type
+    uint32_t flags;
+    uint32_t lastFlags;
+} flightLogEvent_flightMode_t;
 
 typedef struct flightLogEvent_inflightAdjustment_s {
     uint8_t adjustmentFunction;
@@ -135,6 +141,7 @@ typedef struct flightLogEvent_gtuneCycleResult_s {
 
 typedef union flightLogEventData_u {
     flightLogEvent_syncBeep_t syncBeep;
+    flightLogEvent_flightMode_t flightMode; // New event data
     flightLogEvent_inflightAdjustment_t inflightAdjustment;
     flightLogEvent_loggingResume_t loggingResume;
     flightLogEvent_gtuneCycleResult_t gtuneCycleResult;


### PR DESCRIPTION
I would like to propose modification to the blackbox logging system to

1. Add Roll rate, Pitch rate, Yaw rate, rcExpo, rcYawExpo, SuperExpo and looptime settings to log file header.
2. Add event to the log timeline when Flight Mode changes.

Adding these extra header fields will allow the blackbox viewer to use the values to calculate and scale rcCommand to deg/s (for display in the log table), add new graph fields etc.

Adding the mode change events will allow the blackbox viewer to display when different flight modes are selected during flight (in fact all the things that appear in the modes configuration tab in the GUI).

The modification will typically add 80bytes to the log file header (once when log file is created); plus approx 10 bytes every time a mode changes (as we record the last mode and new mode so that we can see what's changed). In the example shown below; I estimate that the log file has grown by 140bytes as there are 6 events plus the header added to the log.

Log files that are created by this modification will still open with the existing blackbox viewer without modification. However to see the enhanced features, a modified version of the blackbox viewer is available for testing this functionality at [https://github.com/GaryKeeble/blackbox-log-viewer/tree/SpectrumAnalyser](url)

![example fft](https://cloud.githubusercontent.com/assets/7362663/14586162/64ab302e-0487-11e6-8c5b-ce824cb15036.png)

![flightevents_1](https://cloud.githubusercontent.com/assets/7362663/14586114/722e4dc8-0485-11e6-888d-44d7156a00e5.png)

![rccommand scale](https://cloud.githubusercontent.com/assets/7362663/14586135/78ff2400-0486-11e6-988e-e140ae794f3a.png)

