### PR TITLE
Added 'ledstrip_visual_beeper' option.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -565,6 +565,7 @@ static void resetConf(void)
 #ifdef LED_STRIP
     applyDefaultColors(masterConfig.colors, CONFIGURABLE_COLOR_COUNT);
     applyDefaultLedStripConfig(masterConfig.ledConfigs);
+    masterConfig.ledstrip_visual_beeper = 0;
 #endif
 
 #ifdef SPRACINGF3

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -119,6 +119,7 @@ typedef struct master_t {
 #ifdef LED_STRIP
     ledConfig_t ledConfigs[MAX_LED_STRIP_LENGTH];
     hsvColor_t colors[CONFIGURABLE_COLOR_COUNT];
+    uint8_t ledstrip_visual_beeper; // suppress LEDLOW mode if beeper is on
 #endif
 
 #ifdef TRANSPONDER

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -386,6 +386,13 @@ int beeperTableEntryCount(void)
     return (int)BEEPER_TABLE_ENTRY_COUNT;
 }
 
+/*
+ * Returns true if the beeper is on, false otherwise
+ */
+bool isBeeperOn(void) {
+    return beeperIsOn;
+}
+
 #else
 
 // Stub out beeper functions if #BEEPER not defined
@@ -397,5 +404,6 @@ uint32_t getArmingBeepTimeMicros(void) {return 0;}
 beeperMode_e beeperModeForTableIndex(int idx) {UNUSED(idx); return BEEPER_SILENCE;}
 const char *beeperNameForTableIndex(int idx) {UNUSED(idx); return NULL;}
 int beeperTableEntryCount(void) {return 0;}
+bool isBeeperOn(void) {return false;}
 
 #endif

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -53,3 +53,4 @@ uint32_t getArmingBeepTimeMicros(void);
 beeperMode_e beeperModeForTableIndex(int idx);
 const char *beeperNameForTableIndex(int idx);
 int beeperTableEntryCount(void);
+bool isBeeperOn(void);

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -34,19 +34,41 @@
 #include "drivers/light_ws2811strip.h"
 #include "drivers/system.h"
 #include "drivers/serial.h"
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+#include "drivers/gpio.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_rx.h"
 
 #include <common/printf.h>
+#include "common/axis.h"
 
 #include "io/rc_controls.h"
 
 #include "sensors/battery.h"
+#include "sensors/sensors.h"
+#include "sensors/boardalignment.h"
+#include "sensors/gyro.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
 
 #include "io/ledstrip.h"
+#include "io/beeper.h"
+#include "io/escservo.h"
+#include "io/gimbal.h"
+#include "io/serial.h"
 
 #include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/imu.h"
+
+#include "telemetry/telemetry.h"
 
 #include "config/runtime_config.h"
 #include "config/config.h"
+#include "config/config_profile.h"
+#include "config/config_master.h"
 
 static bool ledStripInitialised = false;
 static bool ledStripEnabled = true;
@@ -916,7 +938,7 @@ void updateLedStrip(void)
         return;
     }
 
-    if (IS_RC_MODE_ACTIVE(BOXLEDLOW)) {
+    if (IS_RC_MODE_ACTIVE(BOXLEDLOW) && !(masterConfig.ledstrip_visual_beeper && isBeeperOn())) {
         if (ledStripEnabled) {
             ledStripDisable();
             ledStripEnabled = false;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -771,6 +771,9 @@ const clivalue_t valueTable[] = {
     { "magzero_x",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[X], .config.minmax = { -32768,  32767 } },
     { "magzero_y",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Y], .config.minmax = { -32768,  32767 } },
     { "magzero_z",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Z], .config.minmax = { -32768,  32767 } },
+#ifdef LED_STRIP
+    { "ledstrip_visual_beeper",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.ledstrip_visual_beeper, .config.lookup = { TABLE_OFF_ON } },
+#endif
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))


### PR DESCRIPTION
The `ledstrip_visual_beeper` option configures the LED strip to flash every time the beeper is active while the LED strip is set to off with the `LEDLOW` mode. This allows the LED strip to be used as a visual indicator for any warning condition (in particular low voltage alarm), even during conditions when a permanently active LED strip is not desired (i.e. day time flying).