### PR TITLE
Minor improvements to pid loop in mw.c

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -419,11 +419,6 @@ void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims)
     }
 }
 
-void imuUpdateGyro(void)
-{
-    gyroUpdate();
-}
-
 void imuUpdateAttitude(void)
 {
     if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -79,7 +79,6 @@ void imuConfigure(
 float getCosTiltAngle(void);
 void calculateEstimatedAltitude(uint32_t currentTime);
 void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims);
-void imuUpdateGyro(void);
 void imuUpdateAttitude(void);
 float calculateThrottleAngleScale(uint16_t throttle_correction_angle);
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value);
@@ -88,5 +87,4 @@ float calculateAccZLowPassFilterRCTimeConstant(float accz_lpf_hz);
 int16_t imuCalculateHeading(t_fp_vector *vec);
 
 void imuResetAccelerationSum(void);
-void imuUpdateGyro(void);
 void imuUpdateAcc(rollAndPitchTrims_t *accelerometerTrims);


### PR DESCRIPTION
A few minor improvements to `taskMainPidLoopCheck` and related code. Main changes:

1. Added `subTask` prefix to tasks that are not directly called by the scheduler (makes the code a little easier to understand)
2. Moved `mixTable()` call into the motor update subtask
3. Fixed the `haveProcessedAnnexCodeOnce` nonsense by moving the call to `annexCode()`