### PR TITLE
biquad filtering improvements

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -26,7 +26,7 @@ typedef struct filterStatePt1_s {
 /* this holds the data required to update samples thru a filter */
 typedef struct biquad_s {
     float b0, b1, b2, a1, a2;
-    float x1, x2, y1, y2;
+    float d1, d2;
 } biquad_t;
 
 float applyBiQuadFilter(float sample, biquad_t *state);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -202,7 +202,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
             }
         }
 
-        gyroRate = gyroADC[axis] / 4.0f; // gyro output scaled to rewrite scale
+        gyroRate = gyroADCf[axis] / 4.0f; // gyro output scaled to rewrite scale
 
         // --------low-level gyro-based PID. ----------
         // Used in stand-alone mode for ACRO, controlled by higher level regulators in other modes

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -38,6 +38,7 @@
 
 uint16_t calibratingG = 0;
 int32_t gyroADC[XYZ_AXIS_COUNT];
+float gyroADCf[XYZ_AXIS_COUNT];
 int32_t gyroZero[FLIGHT_DYNAMICS_INDEX_COUNT] = { 0, 0, 0 };
 
 static gyroConfig_t *gyroConfig;
@@ -155,7 +156,10 @@ void gyroUpdate(void)
         if (!gyroFilterStateIsSet) initGyroFilterCoefficients(); /* initialise filter coefficients */
 
         if (gyroFilterStateIsSet) {
-            for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) gyroADC[axis] = lrintf(applyBiQuadFilter((float) gyroADC[axis], &gyroFilterState[axis]));
+            for (axis = 0; axis < XYZ_AXIS_COUNT; axis++){
+                gyroADCf[axis] = applyBiQuadFilter((float) gyroADC[axis], &gyroFilterState[axis]);
+                gyroADC[axis] = lrintf(gyroADCf[axis]);
+            }
         }
     }
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -33,6 +33,7 @@ extern gyro_t gyro;
 extern sensor_align_e gyroAlign;
 
 extern int32_t gyroADC[XYZ_AXIS_COUNT];
+extern float gyroADCf[XYZ_AXIS_COUNT];
 extern int32_t gyroZero[FLIGHT_DYNAMICS_INDEX_COUNT];
 
 typedef struct gyroConfig_s {


### PR DESCRIPTION
fix error in biquad coefficients calculation [source](http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt)
improve biquad precision and performance by using direct form 2 transposed instead of direct form 1
[source](http://www.earlevel.com/main/2003/02/28/biquads/)
keep float results for luxfloat pid controller, instead of casting twice to int and back to float