### PR TITLE
Changes to help debug/optimise taskMainPidLoopCheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,9 @@ endif
 
 ifeq ($(TARGET),$(filter $(TARGET), $(CC3D_TARGETS)))
 TARGET_FLAGS := $(TARGET_FLAGS) -DCC3D 
+ifeq ($(TARGET),CC3D_OPBL)
+TARGET_FLAGS := $(TARGET_FLAGS) -DCC3D_OPBL
+endif
 TARGET_DIR = $(ROOT)/src/main/target/CC3D
 endif
 

--- a/src/main/debug.h
+++ b/src/main/debug.h
@@ -42,10 +42,13 @@ extern uint32_t sectionTimes[2][4];
 #endif
 
 typedef enum {
-    DEBUG_CYCLETIME = 1,
+    DEBUG_NONE,
+    DEBUG_CYCLETIME,
     DEBUG_BATTERY,
     DEBUG_GYRO,
     DEBUG_ACCELEROMETER,
     DEBUG_MIXER,
-    DEBUG_AIRMODE
+    DEBUG_AIRMODE,
+    DEBUG_PIDLOOP,
+    DEBUG_COUNT
 } debugType_e;

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -70,11 +70,11 @@ typedef struct drv_pwm_config_s {
 #ifdef USE_SERVOS
     bool useServos;
     bool useChannelForwarding;    // configure additional channels as servos
-#ifdef CC3D
-    bool useBuzzerP6;
-#endif
     uint16_t servoPwmRate;
     uint16_t servoCenterPulse;
+#endif
+#ifdef CC3D
+    bool useBuzzerP6;
 #endif
     bool airplane;       // fixed wing hardware config, lots of servos etc
     uint16_t motorPwmRate;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -62,9 +62,10 @@ int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 uint8_t PIDweight[3];
 
 static int32_t errorGyroI[3], errorGyroILimit[3];
+#ifndef SKIP_PID_LUXFLOAT
 static float errorGyroIf[3], errorGyroIfLimit[3];
-static int32_t errorAngleI[2];
-static float errorAngleIf[2];
+#endif
+
 static bool lowThrottlePidReduction;
 
 static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig,
@@ -103,22 +104,15 @@ uint16_t getDynamicKp(int axis, pidProfile_t *pidProfile) {
     return dynamicKp;
 }
 
-void pidResetErrorAngle(void)
-{
-    errorAngleI[ROLL] = 0;
-    errorAngleI[PITCH] = 0;
-
-    errorAngleIf[ROLL] = 0.0f;
-    errorAngleIf[PITCH] = 0.0f;
-}
-
 void pidResetErrorGyroState(uint8_t resetOption)
 {
     if (resetOption >= RESET_ITERM) {
         int axis;
         for (axis = 0; axis < 3; axis++) {
             errorGyroI[axis] = 0;
+#ifndef SKIP_PID_LUXFLOAT
             errorGyroIf[axis] = 0.0f;
+#endif
         }
     }
 
@@ -141,6 +135,7 @@ const angle_index_t rcAliasToAngleIndexMap[] = { AI_ROLL, AI_PITCH };
 static filterStatePt1_t deltaFilterState[3];
 static filterStatePt1_t yawFilterState;
 
+#ifndef SKIP_PID_LUXFLOAT
 static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig,
         uint16_t max_angle_inclination, rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig)
 {
@@ -280,6 +275,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
 #endif
     }
 }
+#endif
 
 static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig, uint16_t max_angle_inclination,
         rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig)
@@ -426,8 +422,10 @@ void pidSetController(pidControllerType_e type)
         case PID_CONTROLLER_MWREWRITE:
             pid_controller = pidMultiWiiRewrite;
             break;
+#ifndef SKIP_PID_LUXFLOAT
         case PID_CONTROLLER_LUX_FLOAT:
             pid_controller = pidLuxFloat;
+#endif
     }
 }
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -97,7 +97,6 @@ bool antiWindupProtection;
 extern uint32_t targetPidLooptime;
 
 void pidSetController(pidControllerType_e type);
-void pidResetErrorAngle(void);
 void pidResetErrorGyroState(uint8_t resetOption);
 void setTargetPidLooptime(uint8_t pidProcessDenom);
 

--- a/src/main/io/display.h
+++ b/src/main/io/display.h
@@ -15,7 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//#define ENABLE_DEBUG_OLED_PAGE
+#define ENABLE_DEBUG_OLED_PAGE
 
 typedef enum {
     PAGE_WELCOME,

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -26,6 +26,7 @@
 #include "platform.h"
 #include "scheduler.h"
 #include "version.h"
+#include "debug.h"
 
 #include "build_config.h"
 
@@ -426,14 +427,15 @@ static const char * const lookupTableMagHardware[] = {
     "AK8963"
 };
 
-static const char * const lookupTableDebug[] = {
+static const char * const lookupTableDebug[DEBUG_COUNT] = {
     "NONE",
     "CYCLETIME",
     "BATTERY",
     "GYRO",
     "ACCELEROMETER",
     "MIXER",
-    "AIRMODE"
+    "AIRMODE",
+    "PIDLOOP",
 };
 
 static const char * const lookupTableSuperExpoYaw[] = {

--- a/src/main/scheduler.h
+++ b/src/main/scheduler.h
@@ -44,14 +44,14 @@ typedef enum {
     /* Actual tasks */
     TASK_SYSTEM = 0,
     TASK_GYROPID,
-    TASK_ATTITUDE,
     TASK_ACCEL,
+    TASK_ATTITUDE,
+    TASK_RX,
     TASK_SERIAL,
+    TASK_BATTERY,
 #ifdef BEEPER
     TASK_BEEPER,
 #endif
-    TASK_BATTERY,
-    TASK_RX,
 #ifdef GPS
     TASK_GPS,
 #endif

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -135,7 +135,8 @@
 
 #ifdef CC3D_OPBL
 #define SKIP_CLI_COMMAND_HELP
-#define SKIP_PID_LUXFLOAT
+//#define SKIP_PID_LUXFLOAT
+#undef DISPLAY
 #undef SONAR
 #undef GPS
 #endif

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -71,10 +71,6 @@
 #define MAG
 #define USE_MAG_HMC5883
 
-#define INVERTER
-#define BEEPER
-#define DISPLAY
-
 #define USE_VCP
 #define USE_USART1
 #define USE_USART3
@@ -117,28 +113,26 @@
 #define WS2811_DMA_TC_FLAG           DMA1_FLAG_TC6
 #define WS2811_DMA_HANDLER_IDENTIFER DMA1_CH6_HANDLER
 
-#define BLACKBOX
-#define TELEMETRY
-#define SERIAL_RX
-#define SONAR
-#define USE_SERVOS
-#define USE_CLI
-
-#define USE_SERIAL_4WAY_BLHELI_INTERFACE
-
-
-#undef DISPLAY
-#undef SONAR
-//#if defined(OPBL) && defined(USE_SERIAL_1WIRE)
-#undef BARO
-//#undef BLACKBOX
-#undef GPS
-//#endif
-#define SKIP_CLI_COMMAND_HELP
-
 #define SPEKTRUM_BIND
 // USART3, PB11 (Flexport)
 #define BIND_PORT  GPIOB
 #define BIND_PIN   Pin_11
 
-#define USE_QUATERNION
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define INVERTER
+#define BEEPER
+#define DISPLAY
+#define BLACKBOX
+#define TELEMETRY
+#define SERIAL_RX
+#define USE_SERVOS
+#define USE_CLI
+//#define SONAR
+//#define GPS
+
+#undef BARO
+
+#define SKIP_CLI_COMMAND_HELP
+#define SKIP_PID_LUXFLOAT
+

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -128,11 +128,15 @@
 #define SERIAL_RX
 #define USE_SERVOS
 #define USE_CLI
-//#define SONAR
+#define SONAR
 //#define GPS
 
 #undef BARO
 
+#ifdef CC3D_OPBL
 #define SKIP_CLI_COMMAND_HELP
 #define SKIP_PID_LUXFLOAT
+#undef SONAR
+#undef GPS
+#endif
 


### PR DESCRIPTION
A number of changes:

1. Added `debug` instrumentation to time `subTaskMainSubprocesses`, `subTaskPidController`, and `subTaskMotorUpdate`
2. Got debug page in OLED display working
3. Reordered `enums` in `scheduler.h` (and corresponding functions) so that most interesting tasks appear first on OLED display
4. Added PID values to profile page on OLED display
5. Added new `SKIP_PID_LUXFLOAT` build flag so that `CC3D_OPBL` build can use display.
6. Got rid of unused `pidResetErrorAngle` - this was a leftover from MW23.

I made use of the instrumentation and got some interesting results:

subtask | mwr rate mode | mwr horizon mode | lux rate mode | lux horizon mode
--- | --- | --- | --- | ---
subTaskMainSubprocesses | 3-6 | 4-10 | 3-5 | 6-10
subTaskPidController | 55-65 | 65-70 | 160-175 | 170-175
subTaskMotorUpdate | 55-65 | 55-65 | 55-65 | 55-65

Timings are on a CC3D.
Lux is significantly slower than mwr.

However it looks like you could get away with running `subTaskPidController` every time after `gyroUpdate`. The advantage of this is that all gyro values get input into the filters and none are dropped. Some minor changes are needed for the `PTerm` - a moving average could be used, and additionally the `PTerm` probably needs to be normalised to the loop time (`ITerm` and `DTerm` are already normalised.)
