### PR TITLE
Setting gyro scale for fake sensors.

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1861,6 +1861,10 @@ void mspProcess(void)
             waitForSerialPortToFinishTransmitting(candidatePort->port);
             stopMotors();
             handleOneshotFeatureChangeOnRestart();
+            // On real flight controllers, systemReset() will do a soft reset of the device,
+            // reloading the program.  But to support offline testing this flag needs to be
+            // cleared so that the software doesn't continuously attempt to reboot itself.
+            isRebootScheduled = false;
             systemReset();
         }
     }

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -240,6 +240,7 @@ bool fakeGyroDetect(gyro_t *gyro)
     gyro->init = fakeGyroInit;
     gyro->read = fakeGyroRead;
     gyro->temperature = fakeGyroReadTemp;
+    gyro->scale = 1.0f / 16.4f;
     return true;
 }
 #endif


### PR DESCRIPTION
Setting this scale value is required for the IMU to properly compute the rotational quaternion.

Also, in the restart section, just before it issues the reset command it clears the rebootScheduled flag.  I do this to support running the code in a SITL environment where the program soft-resets and doesn't actually restart.