### PR TITLE
Moved RC lookup code into rc_curves.c, plus some minor optimisations

### DIFF
--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -26,9 +26,13 @@
 
 #include "config/config.h"
 
-int16_t lookupPitchRollRC[PITCH_LOOKUP_LENGTH];     // lookup table for expo & RC rate PITCH+ROLL
-int16_t lookupYawRC[YAW_LOOKUP_LENGTH];     // lookup table for expo & RC rate YAW
-int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];   // lookup table for expo & mid THROTTLE
+#define PITCH_LOOKUP_LENGTH 31
+#define YAW_LOOKUP_LENGTH 31
+#define THROTTLE_LOOKUP_LENGTH 12
+
+static int16_t lookupPitchRollRC[PITCH_LOOKUP_LENGTH];      // lookup table for expo & RC rate PITCH+ROLL
+static int16_t lookupYawRC[YAW_LOOKUP_LENGTH];              // lookup table for expo & RC rate YAW
+static int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];    // lookup table for expo & mid THROTTLE
 
 
 void generatePitchRollCurve(controlRateConfig_t *controlRateConfig)
@@ -69,3 +73,23 @@ void generateThrottleCurve(controlRateConfig_t *controlRateConfig, escAndServoCo
         lookupThrottleRC[i] = minThrottle + (int32_t) (escAndServoConfig->maxthrottle - minThrottle) * lookupThrottleRC[i] / 1000; // [MINTHROTTLE;MAXTHROTTLE]
     }
 }
+
+int16_t rcLookupPitchRoll(int32_t tmp)
+{
+    const int32_t tmp2 = tmp / 20;
+    return lookupPitchRollRC[tmp2] + (tmp - tmp2 * 20) * (lookupPitchRollRC[tmp2 + 1] - lookupPitchRollRC[tmp2]) / 20;
+}
+
+int16_t rcLookupYaw(int32_t tmp)
+{
+    const int32_t tmp2 = tmp / 20;
+    return lookupYawRC[tmp2] + (tmp - tmp2 * 20) * (lookupYawRC[tmp2 + 1] - lookupYawRC[tmp2]) / 20;
+}
+
+int16_t rcLookupThrottle(int32_t tmp)
+{
+    const int32_t tmp2 = tmp / 100;
+    // [0;1000] -> expo -> [MINTHROTTLE;MAXTHROTTLE]
+    return lookupThrottleRC[tmp2] + (tmp - tmp2 * 100) * (lookupThrottleRC[tmp2 + 1] - lookupThrottleRC[tmp2]) / 100;
+}
+

--- a/src/main/io/rc_curves.h
+++ b/src/main/io/rc_curves.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
-#define PITCH_LOOKUP_LENGTH 31
-#define YAW_LOOKUP_LENGTH 31
-#define THROTTLE_LOOKUP_LENGTH 12
-extern int16_t lookupPitchRollRC[PITCH_LOOKUP_LENGTH];   // lookup table for expo & RC rate PITCH+ROLL
-extern int16_t lookupYawRC[YAW_LOOKUP_LENGTH];     // lookup table for expo & RC rate YAW
-extern int16_t lookupThrottleRC[THROTTLE_LOOKUP_LENGTH];   // lookup table for expo & mid THROTTLE
-
 void generatePitchRollCurve(controlRateConfig_t *controlRateConfig);
 void generateYawCurve(controlRateConfig_t *controlRateConfig);
 void generateThrottleCurve(controlRateConfig_t *controlRateConfig, escAndServoConfig_t *escAndServoConfig);
+
+int16_t rcLookupPitchRoll(int32_t tmp);
+int16_t rcLookupYaw(int32_t tmp);
+int16_t rcLookupThrottle(int32_t tmp);
+

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -222,7 +222,7 @@ void scaleRcCommandToFpvCamAngle(void) {
 
 void annexCode(void)
 {
-    int32_t tmp, tmp2;
+    int32_t tmp;
     int32_t axis, prop;
 
     // PITCH & ROLL only dynamic PID adjustment,  depending on throttle value
@@ -246,9 +246,7 @@ void annexCode(void)
                     tmp = 0;
                 }
             }
-
-            tmp2 = tmp / 20;
-            rcCommand[axis] = lookupPitchRollRC[tmp2] + (tmp - tmp2 * 20) * (lookupPitchRollRC[tmp2 + 1] - lookupPitchRollRC[tmp2]) / 20;
+            rcCommand[axis] = rcLookupPitchRoll(tmp);
         } else if (axis == YAW) {
             if (masterConfig.rcControlsConfig.yaw_deadband) {
                 if (tmp > masterConfig.rcControlsConfig.yaw_deadband) {
@@ -257,8 +255,7 @@ void annexCode(void)
                     tmp = 0;
                 }
             }
-            tmp2 = tmp / 20;
-            rcCommand[axis] = (lookupYawRC[tmp2] + (tmp - tmp2 * 20) * (lookupYawRC[tmp2 + 1] - lookupYawRC[tmp2]) / 20) * -masterConfig.yaw_control_direction;
+            rcCommand[axis] = rcLookupYaw(tmp) * -masterConfig.yaw_control_direction;
         }
 
         // non coupled PID reduction scaler used in PID controller 1 and PID controller 2.
@@ -275,8 +272,7 @@ void annexCode(void)
         tmp = constrain(rcData[THROTTLE], masterConfig.rxConfig.mincheck, PWM_RANGE_MAX);
         tmp = (uint32_t)(tmp - masterConfig.rxConfig.mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - masterConfig.rxConfig.mincheck);
     }
-    tmp2 = tmp / 100;
-    rcCommand[THROTTLE] = lookupThrottleRC[tmp2] + (tmp - tmp2 * 100) * (lookupThrottleRC[tmp2 + 1] - lookupThrottleRC[tmp2]) / 100;    // [0;1000] -> expo -> [MINTHROTTLE;MAXTHROTTLE]
+    rcCommand[THROTTLE] = rcLookupThrottle(tmp);
 
     if (feature(FEATURE_3D) && IS_RC_MODE_ACTIVE(BOX3DDISABLESWITCH) && !failsafeIsActive()) {
         fix12_t throttleScaler = qConstruct(rcCommand[THROTTLE] - 1000, 1000);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -169,7 +169,8 @@ bool isCalibrating()
     return (!isAccelerationCalibrationComplete() && sensors(SENSOR_ACC)) || (!isGyroCalibrationComplete());
 }
 
-void filterRc(void){
+void filterRc(void)
+{
     static int16_t lastCommand[4] = { 0, 0, 0, 0 };
     static int16_t deltaRC[4] = { 0, 0, 0, 0 };
     static int16_t factor, rcInterpolationFactor;
@@ -287,8 +288,10 @@ static void updateRcCommands(void)
     if (masterConfig.rxConfig.fpvCamAngleDegrees && !FLIGHT_MODE(HEADFREE_MODE)) {
         scaleRcCommandToFpvCamAngle();
     }
+}
 
-
+static void updateLEDs(void)
+{
     if (ARMING_FLAG(ARMED)) {
         LED0_ON;
     } else {
@@ -313,10 +316,6 @@ static void updateRcCommands(void)
 
         warningLedUpdate();
     }
-
-    // Read out gyro temperature. can use it for something somewhere. maybe get MCU temperature instead? lots of fun possibilities.
-    if (gyro.temperature)
-        gyro.temperature(&telemTemperature1);
 }
 
 void mwDisarm(void)
@@ -665,6 +664,11 @@ void subTaskMainSubprocesses(void) {
         filterRc();
     }
 
+    // Read out gyro temperature. can use it for something somewhere. maybe get MCU temperature instead? lots of fun possibilities.
+    if (gyro.temperature) {
+        gyro.temperature(&telemTemperature1);
+    }
+
     #ifdef MAG
             if (sensors(SENSOR_MAG)) {
                 updateMagHold();
@@ -856,6 +860,8 @@ void taskUpdateRxMain(void)
 
     // updateRcCommands sets rcCommand, which is needed by updateAltHoldState and updateSonarAltHoldState
     updateRcCommands();
+    updateLEDs();
+
 #ifdef BARO
     if (sensors(SENSOR_BARO)) {
         updateAltHoldState();


### PR DESCRIPTION
Moved RC lookup into `rc_curves.c` so that any future changes can be made in one place.

Renamed the confusingly named `annexCode` function. Split it into two functions, one called `updateRcCommands` and one called `updateLEDs`. Moved the gyro temperature sensing into `subTaskMainSubprocesses`.

Minor optimisation of deadband handling in `updateRcCommands`.