### PR TITLE
Blackbox Enhancements

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1133,7 +1133,7 @@ static bool blackboxWriteSysinfo()
             blackboxPrintfHeaderLine("Firmware type:Cleanflight");
         break;
         case 1:
-            blackboxPrintfHeaderLine("Firmware revision:Betaflight %s (%s)", FC_VERSION_STRING, shortGitRevision);
+            blackboxPrintfHeaderLine("Firmware revision:Betaflight %s (%s) %s", FC_VERSION_STRING, shortGitRevision, targetName);
         break;
         case 2:
             blackboxPrintfHeaderLine("Firmware date:%s %s", buildDate, buildTime);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1195,7 +1195,7 @@ static bool blackboxWriteSysinfo()
             blackboxPrintfHeaderLine("tpa_breakpoint:%d", masterConfig.profile[masterConfig.current_profile_index].controlRateProfile[masterConfig.profile[masterConfig.current_profile_index].activeRateProfile].tpa_breakpoint);
             break;
         case 19:
-            blackboxPrintfHeaderLine("superExpoFactor:%d", masterConfig.rxConfig.superExpoFactor);
+            blackboxPrintfHeaderLine("superExpoFactor:%d, %d", masterConfig.rxConfig.superExpoFactor, masterConfig.rxConfig.superExpoFactorYaw);
             break;
         case 20:
             blackboxPrintfHeaderLine("rates:%d,%d,%d",
@@ -1333,6 +1333,9 @@ static bool blackboxWriteSysinfo()
             blackboxPrintfHeaderLine("rc_smoothing:%d", masterConfig.rxConfig.rcSmoothing);
             break;
         case 52:
+            blackboxPrintfHeaderLine("superExpoYawMode:%d", masterConfig.rxConfig.superExpoYawMode);
+            break;
+        case 53:
             blackboxPrintfHeaderLine("features:%d", masterConfig.enabledFeatures);
             break;
         default:


### PR DESCRIPTION
@borisbstyle 

I have made some minor modifications to blackbox log header. 

1. Added the build target (targetName) to the header revision field (now we will always know what flight controller board the log was made for).
2. Added superExpoFactorYaw (and it's setting superExpoYawMode) to the header.

Not sure if it's too late for 2.7.0.....


