### PR TITLE
Clean up Doge buzzer code and use correct logic.

### DIFF
--- a/src/main/target/DOGE/target.h
+++ b/src/main/target/DOGE/target.h
@@ -37,12 +37,7 @@
 #define BEEP_GPIO   GPIOB
 #define BEEP_PIN    Pin_2
 #define BEEP_PERIPHERAL RCC_AHBPeriph_GPIOB
-//#define BEEPER_INVERTED
-
-// #define BEEP_GPIO   GPIOB
-// #define BEEP_PIN    Pin_13
-// #define BEEP_PERIPHERAL RCC_AHBPeriph_GPIOB
-// #define BEEPER_INVERTED
+#define BEEPER_INVERTED
 
 // tqfp48 pin 3
 #define MPU6500_CS_GPIO_CLK_PERIPHERAL   RCC_AHBPeriph_GPIOC


### PR DESCRIPTION
Production hardware has buzzer driver, this small changes is required to make it work.