### PR TITLE
Added MSP commands for reading/writing Super Expo settings

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -297,7 +297,7 @@ static uint32_t read32(void)
 static void headSerialResponse(uint8_t err, uint8_t responseBodySize)
 {
     serialBeginWrite(mspSerialPort);
-    
+
     serialize8('$');
     serialize8('M');
     serialize8(err ? '!' : '>');
@@ -874,6 +874,12 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize16(currentControlRateProfile->tpa_breakpoint);
         serialize8(currentControlRateProfile->rcYawExpo8);
         break;
+    case MSP_SUPER_EXPO:
+        headSerialReply(3);
+        serialize8(masterConfig.rxConfig.superExpoFactor);
+        serialize8(masterConfig.rxConfig.superExpoYawMode);
+        serialize8(masterConfig.rxConfig.superExpoFactorYaw);
+        break;
     case MSP_PID:
         headSerialReply(3 * PID_ITEM_COUNT);
         for (i = 0; i < PID_ITEM_COUNT; i++) {
@@ -1358,7 +1364,6 @@ static bool processInCommand(void)
             headSerialError(0);
         }
         break;
-
     case MSP_SET_RC_TUNING:
         if (currentPort->dataSize >= 10) {
             currentControlRateProfile->rcRate8 = read8();
@@ -1378,6 +1383,11 @@ static bool processInCommand(void)
         } else {
             headSerialError(0);
         }
+        break;
+    case MSP_SET_SUPER_EXPO:
+        masterConfig.rxConfig.superExpoFactor = read8();
+        masterConfig.rxConfig.superExpoYawMode = read8();
+        masterConfig.rxConfig.superExpoFactorYaw = read8();
         break;
     case MSP_SET_MISC:
         tmp = read16();

--- a/src/main/io/serial_msp.h
+++ b/src/main/io/serial_msp.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   16 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   17 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 
@@ -217,6 +217,7 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_3D                   124    //out message         Settings needed for reversible ESCs
 #define MSP_RC_DEADBAND          125    //out message         deadbands for yaw alt pitch roll
 #define MSP_SENSOR_ALIGNMENT     126    //out message         orientation of acc,gyro,mag
+#define MSP_SUPER_EXPO           127    //out message         Super expo settings
 
 #define MSP_SET_RAW_RC           200    //in message          8 rc chan
 #define MSP_SET_RAW_GPS          201    //in message          fix, numsat, lat, lon, alt, speed
@@ -237,6 +238,7 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_SET_RC_DEADBAND      218    //in message          deadbands for yaw alt pitch roll
 #define MSP_SET_RESET_CURR_PID   219    //in message          resetting the current pid profile to defaults
 #define MSP_SET_SENSOR_ALIGNMENT 220    //in message          set the orientation of the acc,gyro,mag
+#define MSP_SET_SUPER_EXPO       221    //in message          set super expo settings
 
 // #define MSP_BIND                 240    //in message          no param
 // #define MSP_ALARMS               242


### PR DESCRIPTION
Added commands MSP_SUPER_EXPO and MSP_SET_SUPER_EXPO to change Super Expo settings with MSP commands, e.q. from OSD software.
I've made a super lightweight version of MWOSD to only display most relevant information for race of freestyle flying. In the OSD menu it is possible to change Super Expo settings. To read and write the Super Expo settings from Betaflight, I have implemented two new MSP commands.

Settings that can be changed are:
- Super Expo Factor (0-100)
- Super Expo Yaw mode (ON/OFF)
- Super Expo Yaw Factor (0-100)

Can you please pull this request and integrate it in Betaflight. Thanks.